### PR TITLE
[FEATURE] Implement logic for turning the face colors when turning the cube

### DIFF
--- a/visualizer/src/cube/face.ts
+++ b/visualizer/src/cube/face.ts
@@ -1,5 +1,6 @@
 import { vec3 } from "gl-matrix";
 import type p5 from "p5";
+import {roundToDecimal} from "../utils/math.ts";
 
 /**
  * Class representing a face of a Rubik's Cube piece
@@ -45,6 +46,51 @@ export class Face {
             p.rotateX(p.HALF_PI);
         }
     };
+
+    /**
+     * Turn the face around the X axis
+     *
+     * @param angle - The angle to turn (in radians)
+     *
+     * @example
+     * face.turnX(Math.PI / 2);
+     */
+    turnX(angle: number) : void {
+        // Rotate the face vector around the X axis
+        const newY = roundToDecimal(this.vector[1] * Math.cos(angle) - this.vector[2] * Math.sin(angle), 1);
+        const newZ = roundToDecimal(this.vector[1] * Math.sin(angle) + this.vector[2] * Math.cos(angle), 1);
+        this.vector = vec3.fromValues(this.vector[0], newY, newZ);
+    }
+
+    /**
+     * Turn the face around the Y axis
+     *
+     * @param angle - The angle to turn (in radians)
+     *
+     * @example
+     * face.turnY(Math.PI / 2);
+     */
+    turnY(angle: number) : void {
+        // Rotate the face vector around the Y axis
+        const newX = roundToDecimal(this.vector[0] * Math.cos(angle) - this.vector[2] * Math.sin(angle), 1);
+        const newZ = roundToDecimal(this.vector[0] * Math.sin(angle) + this.vector[2] * Math.cos(angle), 1);
+        this.vector = vec3.fromValues(newX, this.vector[1], newZ);
+    }
+
+    /**
+     * Turn the face around the Z axis
+     *
+     * @param angle - The angle to turn (in radians)
+     *
+     * @example
+     * face.turnZ(Math.PI / 2);
+     */
+    turnZ(angle: number) : void {
+        // Rotate the face vector around the Z axis
+        const newX = roundToDecimal(this.vector[0] * Math.cos(angle) - this.vector[1] * Math.sin(angle), 1);
+        const newY = roundToDecimal(this.vector[0] * Math.sin(angle) + this.vector[1] * Math.cos(angle), 1);
+        this.vector = vec3.fromValues(newX, newY, this.vector[2]);
+    }
 
     /**
      * Display the face

--- a/visualizer/src/cube/piece.ts
+++ b/visualizer/src/cube/piece.ts
@@ -97,6 +97,37 @@ export class Piece {
     };
 
     /**
+     * Update the faces of the piece based on rotation
+     *
+     * @param axis - The axis of rotation ('x', 'y', or 'z')
+     * @param angle - The angle of rotation (in radians)
+     * @throws Error - Will throw an error if the axis is invalid
+     *
+     * @example
+     * const piece = new Piece(1, 1, 1, p);
+     * piece.updateFaces('x', Math.PI / 2);
+     * piece.show();
+     */
+    updateFaces(axis: string, angle: number) : void {
+        // Update face orientations based on the rotation axis
+        this.faces.forEach(face => {
+            switch (axis) {
+                case 'x':
+                    face.turnX(angle);
+                    break;
+                case 'y':
+                    face.turnY(angle);
+                    break;
+                case 'z':
+                    face.turnZ(angle);
+                    break;
+                default:
+                    throw new Error(`Invalid axis: ${axis}`);
+            }
+        });
+    }
+
+    /**
      * Color the faces of the piece based on its position
      * If the piece is on the outer layer, color the corresponding face, else color it black
      *

--- a/visualizer/src/cube/turn.ts
+++ b/visualizer/src/cube/turn.ts
@@ -23,6 +23,8 @@ export const turnX = (pieces: Piece[], angle: number, layerIndexes: number[]) =>
             mat2d.translate(matrix, matrix, [piece.y, piece.z]);
             // Update piece position
             piece.update(piece.x, roundToDecimal(matrix[4], 1), roundToDecimal(matrix[5], 1));
+            // Update faces position
+            piece.updateFaces('x', angle);
         }
     });
 };
@@ -48,6 +50,8 @@ export const turnY = (pieces: Piece[], angle: number, layerIndexes: number[]) =>
             mat2d.translate(matrix, matrix, [piece.x, piece.z]);
             // Update piece position
             piece.update(roundToDecimal(matrix[4], 1), piece.y, roundToDecimal(matrix[5], 1));
+            // Update faces position
+            piece.updateFaces('y', angle);
         }
     });
 };
@@ -73,6 +77,8 @@ export const turnZ = (pieces: Piece[], angle: number, layerIndexes: number[]) =>
             mat2d.translate(matrix, matrix, [piece.x, piece.y]);
             // Update piece position
             piece.update(roundToDecimal(matrix[4], 1), roundToDecimal(matrix[5], 1), piece.z);
+            // Update faces position
+            piece.updateFaces('z', angle);
         }
     });
 };

--- a/visualizer/src/sketch/sketch.ts
+++ b/visualizer/src/sketch/sketch.ts
@@ -10,7 +10,7 @@ import { Cube } from "../cube/cube";
  * new p5(cubeSketch, document.getElementById("visualizer") as HTMLElement);
  */
 export const cubeSketch = (p: p5) => {
-    const dim = 20;
+    const dim = 4;
     let cube: Cube;
     let lastTime = performance.now();
     let frameCount = 0;
@@ -87,12 +87,12 @@ export const cubeSketch = (p: p5) => {
     p.keyPressed = (key: KeyboardEvent) : void => {
         console.log(`Key pressed: ${key.key}`);
         if (key.key === 's') {
-            let scramble = "Dw";
+            let scramble = "Dw2 B' U' L' F2 B Lw U2 L' R2 F' D2 Fw' L2 Bw L2 D2 B D2 F R2";
             let splitScramble = scramble.split(" ");
             for (let i = 0; i < splitScramble.length; i++) {
                 setTimeout(() => {
                     cube.turn(splitScramble[i]);
-                }, i * 1000);
+                }, i * 100);
             }
         }
     };


### PR DESCRIPTION
This pull request enhances the Rubik's Cube visualizer by improving the accuracy of face orientation during piece rotations and updating the scramble used for testing. The main changes introduce methods to rotate individual faces along each axis, ensure piece faces are updated to match their new orientation after a turn, and make the scramble more complex for better demonstration.

**Face orientation and rotation improvements:**

* Added `turnX`, `turnY`, and `turnZ` methods to the `Face` class in `face.ts` to allow precise rotation of face vectors around the X, Y, and Z axes, respectively. These methods use trigonometric calculations and rounding for accuracy.
* Added an `updateFaces` method to the `Piece` class in `piece.ts`, which applies the appropriate face rotation based on the axis and angle whenever a piece is turned.
* Updated the `turnX`, `turnY`, and `turnZ` functions in `turn.ts` to call `updateFaces` on each affected piece, ensuring face orientations remain consistent with piece positions after a turn. [[1]](diffhunk://#diff-f19a4ebe08c543e8529bb5d47037973832062d1455a2dcbf96aaa77821a9ebf3R26-R27) [[2]](diffhunk://#diff-f19a4ebe08c543e8529bb5d47037973832062d1455a2dcbf96aaa77821a9ebf3R53-R54) [[3]](diffhunk://#diff-f19a4ebe08c543e8529bb5d47037973832062d1455a2dcbf96aaa77821a9ebf3R80-R81)
* Imported the `roundToDecimal` utility in `face.ts` to support precise rounding in face rotation calculations.

Resolves #87 