### PR TITLE
[FIX] Fixed an import in the cube file of the visualizer

### DIFF
--- a/visualizer/src/cube/cube.ts
+++ b/visualizer/src/cube/cube.ts
@@ -2,7 +2,7 @@ import type p5 from "p5";
 
 import { Move } from "./move";
 import { Piece } from "./piece";
-import { Animation } from "./animation.ts";
+import { Animation } from "./animation";
 import { turnX, turnY, turnZ } from "./turn";
 import { roundToDecimal } from "../utils/math";
 


### PR DESCRIPTION
This pull request makes a minor change to the import statement in `cube.ts`, fixing the import path for the `Animation` module to remove the `.ts` extension. This helps ensure compatibility with module resolution in various build tools and environments.