### PR TITLE
[FEATURE] Validator 3x3 Checks

### DIFF
--- a/solver/src/rubik_cube_solver/validator/validator.py
+++ b/solver/src/rubik_cube_solver/validator/validator.py
@@ -5,65 +5,15 @@ from collections import Counter
 from rubik_cube_solver.cube import Cube
 from rubik_cube_solver.enums.Color import Color
 from rubik_cube_solver.enums.Layer import Layer
-
-_VALID_CORNER_COLOR_SETS: frozenset[frozenset[Color]] = frozenset(
-    {
-        frozenset({Color.WHITE, Color.GREEN, Color.ORANGE}),
-        frozenset({Color.WHITE, Color.GREEN, Color.RED}),
-        frozenset({Color.WHITE, Color.BLUE, Color.ORANGE}),
-        frozenset({Color.WHITE, Color.BLUE, Color.RED}),
-        frozenset({Color.YELLOW, Color.GREEN, Color.ORANGE}),
-        frozenset({Color.YELLOW, Color.GREEN, Color.RED}),
-        frozenset({Color.YELLOW, Color.BLUE, Color.ORANGE}),
-        frozenset({Color.YELLOW, Color.BLUE, Color.RED}),
-    }
+from rubik_cube_solver.validator.validator_constants import (
+    CENTER_COLORS_OPPOSITES,
+    CENTER_LAYER_OPPOSITES,
+    CORNER_CANONICAL_CW,
+    EDGE_CANONICAL_ORIENTATION,
+    VALID_CORNER_COLOR_SETS,
+    VALID_EDGE_COLOR_SETS,
 )
-
-# Canonical CW sequence for each valid corner color set
-_CORNER_CANONICAL_CW: dict[frozenset[Color], tuple[Color, Color, Color]] = {
-    frozenset({Color.WHITE, Color.GREEN, Color.ORANGE}): (Color.WHITE, Color.GREEN, Color.ORANGE),
-    frozenset({Color.WHITE, Color.GREEN, Color.RED}): (Color.WHITE, Color.RED, Color.GREEN),
-    frozenset({Color.WHITE, Color.BLUE, Color.ORANGE}): (Color.WHITE, Color.ORANGE, Color.BLUE),
-    frozenset({Color.WHITE, Color.BLUE, Color.RED}): (Color.WHITE, Color.BLUE, Color.RED),
-    frozenset({Color.YELLOW, Color.GREEN, Color.ORANGE}): (Color.YELLOW, Color.ORANGE, Color.GREEN),
-    frozenset({Color.YELLOW, Color.GREEN, Color.RED}): (Color.YELLOW, Color.GREEN, Color.RED),
-    frozenset({Color.YELLOW, Color.BLUE, Color.ORANGE}): (Color.YELLOW, Color.BLUE, Color.ORANGE),
-    frozenset({Color.YELLOW, Color.BLUE, Color.RED}): (Color.YELLOW, Color.RED, Color.BLUE),
-}
-
-_VALID_EDGE_COLOR_SETS: frozenset[frozenset[Color]] = frozenset(
-    {
-        frozenset({Color.WHITE, Color.GREEN}),
-        frozenset({Color.WHITE, Color.BLUE}),
-        frozenset({Color.WHITE, Color.ORANGE}),
-        frozenset({Color.WHITE, Color.RED}),
-        frozenset({Color.YELLOW, Color.GREEN}),
-        frozenset({Color.YELLOW, Color.BLUE}),
-        frozenset({Color.YELLOW, Color.ORANGE}),
-        frozenset({Color.YELLOW, Color.RED}),
-        frozenset({Color.GREEN, Color.ORANGE}),
-        frozenset({Color.GREEN, Color.RED}),
-        frozenset({Color.BLUE, Color.ORANGE}),
-        frozenset({Color.BLUE, Color.RED}),
-    }
-)
-
-# For each edge color set, the primary color is the one that should face UP/DOWN (for U/D edges)
-# or FRONT/BACK (for equatorial edges) to be considered "oriented" (orientation = 0)
-_EDGE_CANONICAL_ORIENTATION: dict[frozenset[Color], Color] = {
-    frozenset({Color.WHITE, Color.GREEN}): Color.WHITE,
-    frozenset({Color.WHITE, Color.BLUE}): Color.WHITE,
-    frozenset({Color.WHITE, Color.ORANGE}): Color.WHITE,
-    frozenset({Color.WHITE, Color.RED}): Color.WHITE,
-    frozenset({Color.YELLOW, Color.GREEN}): Color.YELLOW,
-    frozenset({Color.YELLOW, Color.BLUE}): Color.YELLOW,
-    frozenset({Color.YELLOW, Color.ORANGE}): Color.YELLOW,
-    frozenset({Color.YELLOW, Color.RED}): Color.YELLOW,
-    frozenset({Color.GREEN, Color.ORANGE}): Color.GREEN,
-    frozenset({Color.GREEN, Color.RED}): Color.GREEN,
-    frozenset({Color.BLUE, Color.ORANGE}): Color.BLUE,
-    frozenset({Color.BLUE, Color.RED}): Color.BLUE,
-}
+from rubik_cube_solver.validator.validator_utils import get_corners, get_edges
 
 
 class Validator:
@@ -86,7 +36,7 @@ class Validator:
         self._check_corner_orientation(cube)
         self._check_corner_chirality(cube)
 
-        if cube.size == 3:
+        if cube.size % 2 == 1:
             self._check_center_uniqueness(cube)
             self._check_edge_validity(cube)
             self._check_edge_flip_parity(cube)
@@ -126,38 +76,6 @@ class Validator:
                 )
 
     @staticmethod
-    def _get_corners(cube: Cube) -> list[tuple[Color, Color, Color]]:
-        """
-        Returns a list of 8 corner tuples, one per corner, each containing the 3 sticker
-        colors in the canonical clockwise face-sequence order.
-
-        :param cube: The Cube instance
-        :return: List of 8 corner color tuples
-        """
-
-        n = cube.size
-        layers = cube.layers
-        # Each entry: (face1_color, face2_color, face3_color) in CW order
-        return [
-            # UFL
-            (layers[Layer.UP][n * (n - 1)], layers[Layer.FRONT][0], layers[Layer.LEFT][n - 1]),
-            # UFR
-            (layers[Layer.UP][n * n - 1], layers[Layer.RIGHT][0], layers[Layer.FRONT][n - 1]),
-            # UBL
-            (layers[Layer.UP][0], layers[Layer.LEFT][0], layers[Layer.BACK][n - 1]),
-            # UBR
-            (layers[Layer.UP][n - 1], layers[Layer.BACK][0], layers[Layer.RIGHT][n - 1]),
-            # DFL
-            (layers[Layer.DOWN][0], layers[Layer.LEFT][n * n - 1], layers[Layer.FRONT][n * (n - 1)]),
-            # DFR
-            (layers[Layer.DOWN][n - 1], layers[Layer.FRONT][n * n - 1], layers[Layer.RIGHT][n * (n - 1)]),
-            # DBL
-            (layers[Layer.DOWN][n * (n - 1)], layers[Layer.BACK][n * n - 1], layers[Layer.LEFT][n * (n - 1)]),
-            # DBR
-            (layers[Layer.DOWN][n * n - 1], layers[Layer.RIGHT][n * n - 1], layers[Layer.BACK][n * (n - 1)]),
-        ]
-
-    @staticmethod
     def _check_corner_validity(cube: Cube) -> None:
         """
         Validates that all 8 corner pieces are present exactly once with valid 3-color combinations.
@@ -166,12 +84,12 @@ class Validator:
         :return: None
         """
 
-        corners = Validator._get_corners(cube)
+        corners = get_corners(cube)
         seen_color_sets: list[frozenset[Color]] = []
 
         for corner in corners:
             colors = frozenset(corner)
-            if colors not in _VALID_CORNER_COLOR_SETS:
+            if colors not in VALID_CORNER_COLOR_SETS:
                 raise ValueError(f"Invalid corner piece: {colors}.")
             if colors in seen_color_sets:
                 raise ValueError(f"Duplicate corner piece: {colors}.")
@@ -186,7 +104,7 @@ class Validator:
         :return: None
         """
 
-        corners = Validator._get_corners(cube)
+        corners = get_corners(cube)
         ud_colors = {Color.WHITE, Color.YELLOW}
         total = 0
 
@@ -215,12 +133,12 @@ class Validator:
         :return: None
         """
 
-        corners = Validator._get_corners(cube)
+        corners = get_corners(cube)
 
         for corner in corners:
             c0, c1, c2 = corner
             color_set = frozenset({c0, c1, c2})
-            canonical = _CORNER_CANONICAL_CW[color_set]
+            canonical = CORNER_CANONICAL_CW[color_set]
             valid_rotations = {
                 canonical,
                 (canonical[1], canonical[2], canonical[0]),
@@ -230,47 +148,9 @@ class Validator:
                 raise ValueError(f"Invalid corner chirality for piece {color_set}.")
 
     @staticmethod
-    def _get_edges(cube: Cube) -> list[tuple[Color, Color]]:
-        """
-        Returns a list of 12 edge tuples in canonical order (UF, UB, UL, UR, DF, DB, DL, DR, FL, FR, BL, BR).
-        Each tuple is (face1_color, face2_color) as defined by the sticker index table.
-
-        :param cube: The Cube instance
-        :return: List of 12 edge color tuples
-        """
-
-        layers = cube.layers
-        return [
-            # UF
-            (layers[Layer.UP][7], layers[Layer.FRONT][1]),
-            # UB
-            (layers[Layer.UP][1], layers[Layer.BACK][1]),
-            # UL
-            (layers[Layer.UP][3], layers[Layer.LEFT][1]),
-            # UR
-            (layers[Layer.UP][5], layers[Layer.RIGHT][1]),
-            # DF
-            (layers[Layer.DOWN][1], layers[Layer.FRONT][7]),
-            # DB
-            (layers[Layer.DOWN][7], layers[Layer.BACK][7]),
-            # DL
-            (layers[Layer.DOWN][3], layers[Layer.LEFT][7]),
-            # DR
-            (layers[Layer.DOWN][5], layers[Layer.RIGHT][7]),
-            # FL
-            (layers[Layer.FRONT][3], layers[Layer.LEFT][5]),
-            # FR
-            (layers[Layer.FRONT][5], layers[Layer.RIGHT][3]),
-            # BL
-            (layers[Layer.BACK][5], layers[Layer.LEFT][3]),
-            # BR
-            (layers[Layer.BACK][3], layers[Layer.RIGHT][5]),
-        ]
-
-    @staticmethod
     def _check_center_uniqueness(cube: Cube) -> None:
         """
-        Validates that all 6 center stickers of a 3x3 cube are distinct colors.
+        Validates that all 6 center stickers of an odd sized cube are distinct colors.
 
         :param cube: The Cube instance to validate
         :return: None
@@ -278,10 +158,25 @@ class Validator:
 
         seen_colors: list[Color] = []
         for face in Layer:
-            center_color = cube.layers[face][4]
+            center_color = cube.layers[face][cube.size // 2]
             if center_color in seen_colors:
                 raise ValueError(f"Duplicate center piece: {center_color}.")
             seen_colors.append(center_color)
+
+    @staticmethod
+    def _check_center_opposites(cube: Cube) -> None:
+        """
+        Validates that all 6 center stickers of an odd sized cube have correct opposite colors.
+
+        :param cube: The Cube instance to validate
+        :return: None
+        """
+
+        for face in Layer:
+            center_color = cube.layers[face][cube.size // 2]
+            opposite_color = cube.layers[CENTER_LAYER_OPPOSITES[face]][cube.size // 2]
+            if CENTER_COLORS_OPPOSITES[center_color] != opposite_color:
+                raise ValueError(f"Invalid opposite color of {center_color}: {opposite_color}.")
 
     @staticmethod
     def _check_edge_validity(cube: Cube) -> None:
@@ -292,12 +187,12 @@ class Validator:
         :return: None
         """
 
-        edges = Validator._get_edges(cube)
+        edges = get_edges(cube)
         seen_color_sets: list[frozenset[Color]] = []
 
         for edge in edges:
             colors = frozenset(edge)
-            if colors not in _VALID_EDGE_COLOR_SETS:
+            if colors not in VALID_EDGE_COLOR_SETS:
                 raise ValueError(f"Invalid edge piece: {colors}.")
             if colors in seen_color_sets:
                 raise ValueError(f"Duplicate edge piece: {colors}.")
@@ -312,11 +207,11 @@ class Validator:
         :return: None
         """
 
-        edges = Validator._get_edges(cube)
+        edges = get_edges(cube)
         total = 0
 
         for c1, c2 in edges:
-            primary_color = _EDGE_CANONICAL_ORIENTATION[frozenset({c1, c2})]
+            primary_color = EDGE_CANONICAL_ORIENTATION[frozenset({c1, c2})]
             if c1 == primary_color:
                 total += 0
             else:
@@ -360,10 +255,10 @@ class Validator:
             frozenset({Color.BLUE, Color.RED}),  # BR
         ]
 
-        corners = Validator._get_corners(cube)
+        corners = get_corners(cube)
         corner_perm = [canonical_corners.index(frozenset(corner)) for corner in corners]
 
-        edges = Validator._get_edges(cube)
+        edges = get_edges(cube)
         edge_perm = [canonical_edges.index(frozenset(edge)) for edge in edges]
 
         def count_inversions(perm: list[int]) -> int:

--- a/solver/src/rubik_cube_solver/validator/validator.py
+++ b/solver/src/rubik_cube_solver/validator/validator.py
@@ -31,6 +31,40 @@ _CORNER_CANONICAL_CW: dict[frozenset[Color], tuple[Color, Color, Color]] = {
     frozenset({Color.YELLOW, Color.BLUE, Color.RED}): (Color.YELLOW, Color.RED, Color.BLUE),
 }
 
+_VALID_EDGE_COLOR_SETS: frozenset[frozenset[Color]] = frozenset(
+    {
+        frozenset({Color.WHITE, Color.GREEN}),
+        frozenset({Color.WHITE, Color.BLUE}),
+        frozenset({Color.WHITE, Color.ORANGE}),
+        frozenset({Color.WHITE, Color.RED}),
+        frozenset({Color.YELLOW, Color.GREEN}),
+        frozenset({Color.YELLOW, Color.BLUE}),
+        frozenset({Color.YELLOW, Color.ORANGE}),
+        frozenset({Color.YELLOW, Color.RED}),
+        frozenset({Color.GREEN, Color.ORANGE}),
+        frozenset({Color.GREEN, Color.RED}),
+        frozenset({Color.BLUE, Color.ORANGE}),
+        frozenset({Color.BLUE, Color.RED}),
+    }
+)
+
+# For each edge color set, the primary color is the one that should face UP/DOWN (for U/D edges)
+# or FRONT/BACK (for equatorial edges) to be considered "oriented" (orientation = 0)
+_EDGE_CANONICAL_ORIENTATION: dict[frozenset[Color], Color] = {
+    frozenset({Color.WHITE, Color.GREEN}): Color.WHITE,
+    frozenset({Color.WHITE, Color.BLUE}): Color.WHITE,
+    frozenset({Color.WHITE, Color.ORANGE}): Color.WHITE,
+    frozenset({Color.WHITE, Color.RED}): Color.WHITE,
+    frozenset({Color.YELLOW, Color.GREEN}): Color.YELLOW,
+    frozenset({Color.YELLOW, Color.BLUE}): Color.YELLOW,
+    frozenset({Color.YELLOW, Color.ORANGE}): Color.YELLOW,
+    frozenset({Color.YELLOW, Color.RED}): Color.YELLOW,
+    frozenset({Color.GREEN, Color.ORANGE}): Color.GREEN,
+    frozenset({Color.GREEN, Color.RED}): Color.GREEN,
+    frozenset({Color.BLUE, Color.ORANGE}): Color.BLUE,
+    frozenset({Color.BLUE, Color.RED}): Color.BLUE,
+}
+
 
 class Validator:
     """
@@ -51,6 +85,12 @@ class Validator:
         self._check_corner_validity(cube)
         self._check_corner_orientation(cube)
         self._check_corner_chirality(cube)
+
+        if cube.size == 3:
+            self._check_center_uniqueness(cube)
+            self._check_edge_validity(cube)
+            self._check_edge_flip_parity(cube)
+            self._check_permutation_parity(cube)
 
     @staticmethod
     def _check_size(cube: Cube) -> None:
@@ -188,3 +228,154 @@ class Validator:
             }
             if (c0, c1, c2) not in valid_rotations:
                 raise ValueError(f"Invalid corner chirality for piece {color_set}.")
+
+    @staticmethod
+    def _get_edges(cube: Cube) -> list[tuple[Color, Color]]:
+        """
+        Returns a list of 12 edge tuples in canonical order (UF, UB, UL, UR, DF, DB, DL, DR, FL, FR, BL, BR).
+        Each tuple is (face1_color, face2_color) as defined by the sticker index table.
+
+        :param cube: The Cube instance
+        :return: List of 12 edge color tuples
+        """
+
+        layers = cube.layers
+        return [
+            # UF
+            (layers[Layer.UP][7], layers[Layer.FRONT][1]),
+            # UB
+            (layers[Layer.UP][1], layers[Layer.BACK][1]),
+            # UL
+            (layers[Layer.UP][3], layers[Layer.LEFT][1]),
+            # UR
+            (layers[Layer.UP][5], layers[Layer.RIGHT][1]),
+            # DF
+            (layers[Layer.DOWN][1], layers[Layer.FRONT][7]),
+            # DB
+            (layers[Layer.DOWN][7], layers[Layer.BACK][7]),
+            # DL
+            (layers[Layer.DOWN][3], layers[Layer.LEFT][7]),
+            # DR
+            (layers[Layer.DOWN][5], layers[Layer.RIGHT][7]),
+            # FL
+            (layers[Layer.FRONT][3], layers[Layer.LEFT][5]),
+            # FR
+            (layers[Layer.FRONT][5], layers[Layer.RIGHT][3]),
+            # BL
+            (layers[Layer.BACK][5], layers[Layer.LEFT][3]),
+            # BR
+            (layers[Layer.BACK][3], layers[Layer.RIGHT][5]),
+        ]
+
+    @staticmethod
+    def _check_center_uniqueness(cube: Cube) -> None:
+        """
+        Validates that all 6 center stickers of a 3x3 cube are distinct colors.
+
+        :param cube: The Cube instance to validate
+        :return: None
+        """
+
+        seen_colors: list[Color] = []
+        for face in Layer:
+            center_color = cube.layers[face][4]
+            if center_color in seen_colors:
+                raise ValueError(f"Duplicate center piece: {center_color}.")
+            seen_colors.append(center_color)
+
+    @staticmethod
+    def _check_edge_validity(cube: Cube) -> None:
+        """
+        Validates that all 12 edge pieces are present exactly once with valid 2-color combinations.
+
+        :param cube: The Cube instance to validate
+        :return: None
+        """
+
+        edges = Validator._get_edges(cube)
+        seen_color_sets: list[frozenset[Color]] = []
+
+        for edge in edges:
+            colors = frozenset(edge)
+            if colors not in _VALID_EDGE_COLOR_SETS:
+                raise ValueError(f"Invalid edge piece: {colors}.")
+            if colors in seen_color_sets:
+                raise ValueError(f"Duplicate edge piece: {colors}.")
+            seen_color_sets.append(colors)
+
+    @staticmethod
+    def _check_edge_flip_parity(cube: Cube) -> None:
+        """
+        Validates that the sum of all 12 edge orientations is divisible by 2.
+
+        :param cube: The Cube instance to validate
+        :return: None
+        """
+
+        edges = Validator._get_edges(cube)
+        total = 0
+
+        for c1, c2 in edges:
+            primary_color = _EDGE_CANONICAL_ORIENTATION[frozenset({c1, c2})]
+            if c1 == primary_color:
+                total += 0
+            else:
+                total += 1
+
+        if total % 2 != 0:
+            raise ValueError(f"Invalid edge flip parity: sum of orientations is {total}, expected a multiple of 2.")
+
+    @staticmethod
+    def _check_permutation_parity(cube: Cube) -> None:
+        """
+        Validates that corner and edge permutations share the same parity (both even or both odd).
+
+        :param cube: The Cube instance to validate
+        :return: None
+        """
+
+        canonical_corners: list[frozenset[Color]] = [
+            frozenset({Color.WHITE, Color.GREEN, Color.ORANGE}),  # UFL
+            frozenset({Color.WHITE, Color.GREEN, Color.RED}),  # UFR
+            frozenset({Color.WHITE, Color.ORANGE, Color.BLUE}),  # UBL
+            frozenset({Color.WHITE, Color.BLUE, Color.RED}),  # UBR
+            frozenset({Color.YELLOW, Color.ORANGE, Color.GREEN}),  # DFL
+            frozenset({Color.YELLOW, Color.GREEN, Color.RED}),  # DFR
+            frozenset({Color.YELLOW, Color.BLUE, Color.ORANGE}),  # DBL
+            frozenset({Color.YELLOW, Color.BLUE, Color.RED}),  # DBR
+        ]
+
+        canonical_edges: list[frozenset[Color]] = [
+            frozenset({Color.WHITE, Color.GREEN}),  # UF
+            frozenset({Color.WHITE, Color.BLUE}),  # UB
+            frozenset({Color.WHITE, Color.ORANGE}),  # UL
+            frozenset({Color.WHITE, Color.RED}),  # UR
+            frozenset({Color.YELLOW, Color.GREEN}),  # DF
+            frozenset({Color.YELLOW, Color.BLUE}),  # DB
+            frozenset({Color.YELLOW, Color.ORANGE}),  # DL
+            frozenset({Color.YELLOW, Color.RED}),  # DR
+            frozenset({Color.GREEN, Color.ORANGE}),  # FL
+            frozenset({Color.GREEN, Color.RED}),  # FR
+            frozenset({Color.BLUE, Color.ORANGE}),  # BL
+            frozenset({Color.BLUE, Color.RED}),  # BR
+        ]
+
+        corners = Validator._get_corners(cube)
+        corner_perm = [canonical_corners.index(frozenset(corner)) for corner in corners]
+
+        edges = Validator._get_edges(cube)
+        edge_perm = [canonical_edges.index(frozenset(edge)) for edge in edges]
+
+        def count_inversions(perm: list[int]) -> int:
+            inversions = 0
+            for i in range(len(perm)):
+                for j in range(i + 1, len(perm)):
+                    if perm[i] > perm[j]:
+                        inversions += 1
+            return inversions
+
+        corner_parity = count_inversions(corner_perm) % 2
+        edge_parity = count_inversions(edge_perm) % 2
+
+        if corner_parity != edge_parity:
+            raise ValueError("Invalid permutation parity: corner and edge permutations have different parities.")

--- a/solver/src/rubik_cube_solver/validator/validator_constants.py
+++ b/solver/src/rubik_cube_solver/validator/validator_constants.py
@@ -1,0 +1,80 @@
+# Project imports
+from rubik_cube_solver.enums.Color import Color
+from rubik_cube_solver.enums.Layer import Layer
+
+VALID_CORNER_COLOR_SETS: frozenset[frozenset[Color]] = frozenset(
+    {
+        frozenset({Color.WHITE, Color.GREEN, Color.ORANGE}),
+        frozenset({Color.WHITE, Color.GREEN, Color.RED}),
+        frozenset({Color.WHITE, Color.BLUE, Color.ORANGE}),
+        frozenset({Color.WHITE, Color.BLUE, Color.RED}),
+        frozenset({Color.YELLOW, Color.GREEN, Color.ORANGE}),
+        frozenset({Color.YELLOW, Color.GREEN, Color.RED}),
+        frozenset({Color.YELLOW, Color.BLUE, Color.ORANGE}),
+        frozenset({Color.YELLOW, Color.BLUE, Color.RED}),
+    }
+)
+
+# Canonical CW sequence for each valid corner color set
+CORNER_CANONICAL_CW: dict[frozenset[Color], tuple[Color, Color, Color]] = {
+    frozenset({Color.WHITE, Color.GREEN, Color.ORANGE}): (Color.WHITE, Color.GREEN, Color.ORANGE),
+    frozenset({Color.WHITE, Color.GREEN, Color.RED}): (Color.WHITE, Color.RED, Color.GREEN),
+    frozenset({Color.WHITE, Color.BLUE, Color.ORANGE}): (Color.WHITE, Color.ORANGE, Color.BLUE),
+    frozenset({Color.WHITE, Color.BLUE, Color.RED}): (Color.WHITE, Color.BLUE, Color.RED),
+    frozenset({Color.YELLOW, Color.GREEN, Color.ORANGE}): (Color.YELLOW, Color.ORANGE, Color.GREEN),
+    frozenset({Color.YELLOW, Color.GREEN, Color.RED}): (Color.YELLOW, Color.GREEN, Color.RED),
+    frozenset({Color.YELLOW, Color.BLUE, Color.ORANGE}): (Color.YELLOW, Color.BLUE, Color.ORANGE),
+    frozenset({Color.YELLOW, Color.BLUE, Color.RED}): (Color.YELLOW, Color.RED, Color.BLUE),
+}
+
+VALID_EDGE_COLOR_SETS: frozenset[frozenset[Color]] = frozenset(
+    {
+        frozenset({Color.WHITE, Color.GREEN}),
+        frozenset({Color.WHITE, Color.BLUE}),
+        frozenset({Color.WHITE, Color.ORANGE}),
+        frozenset({Color.WHITE, Color.RED}),
+        frozenset({Color.YELLOW, Color.GREEN}),
+        frozenset({Color.YELLOW, Color.BLUE}),
+        frozenset({Color.YELLOW, Color.ORANGE}),
+        frozenset({Color.YELLOW, Color.RED}),
+        frozenset({Color.GREEN, Color.ORANGE}),
+        frozenset({Color.GREEN, Color.RED}),
+        frozenset({Color.BLUE, Color.ORANGE}),
+        frozenset({Color.BLUE, Color.RED}),
+    }
+)
+
+# For each edge color set, the primary color is the one that should face UP/DOWN (for U/D edges)
+# or FRONT/BACK (for equatorial edges) to be considered "oriented" (orientation = 0)
+EDGE_CANONICAL_ORIENTATION: dict[frozenset[Color], Color] = {
+    frozenset({Color.WHITE, Color.GREEN}): Color.WHITE,
+    frozenset({Color.WHITE, Color.BLUE}): Color.WHITE,
+    frozenset({Color.WHITE, Color.ORANGE}): Color.WHITE,
+    frozenset({Color.WHITE, Color.RED}): Color.WHITE,
+    frozenset({Color.YELLOW, Color.GREEN}): Color.YELLOW,
+    frozenset({Color.YELLOW, Color.BLUE}): Color.YELLOW,
+    frozenset({Color.YELLOW, Color.ORANGE}): Color.YELLOW,
+    frozenset({Color.YELLOW, Color.RED}): Color.YELLOW,
+    frozenset({Color.GREEN, Color.ORANGE}): Color.GREEN,
+    frozenset({Color.GREEN, Color.RED}): Color.GREEN,
+    frozenset({Color.BLUE, Color.ORANGE}): Color.BLUE,
+    frozenset({Color.BLUE, Color.RED}): Color.BLUE,
+}
+
+CENTER_COLORS_OPPOSITES: dict[Color, Color] = {
+    Color.WHITE: Color.YELLOW,
+    Color.YELLOW: Color.WHITE,
+    Color.GREEN: Color.BLUE,
+    Color.BLUE: Color.GREEN,
+    Color.ORANGE: Color.RED,
+    Color.RED: Color.ORANGE,
+}
+
+CENTER_LAYER_OPPOSITES: dict[Layer, Layer] = {
+    Layer.UP: Layer.DOWN,
+    Layer.DOWN: Layer.UP,
+    Layer.FRONT: Layer.BACK,
+    Layer.BACK: Layer.FRONT,
+    Layer.LEFT: Layer.RIGHT,
+    Layer.RIGHT: Layer.LEFT,
+}

--- a/solver/src/rubik_cube_solver/validator/validator_utils.py
+++ b/solver/src/rubik_cube_solver/validator/validator_utils.py
@@ -1,0 +1,82 @@
+# Project imports
+from rubik_cube_solver.cube import Cube
+from rubik_cube_solver.enums.Color import Color
+from rubik_cube_solver.enums.Layer import Layer
+
+
+def get_corners(cube: Cube) -> list[tuple[Color, Color, Color]]:
+    """
+    Returns a list of 8 corner tuples, one per corner, each containing the 3 sticker
+    colors in the canonical clockwise face-sequence order.
+
+    :param cube: The Cube instance
+    :return: List of 8 corner color tuples
+    """
+
+    n = cube.size
+    layers = cube.layers
+    # Each entry: (face1_color, face2_color, face3_color) in CW order
+    return [
+        # UFL
+        (layers[Layer.UP][n * (n - 1)], layers[Layer.FRONT][0], layers[Layer.LEFT][n - 1]),
+        # UFR
+        (layers[Layer.UP][n * n - 1], layers[Layer.RIGHT][0], layers[Layer.FRONT][n - 1]),
+        # UBL
+        (layers[Layer.UP][0], layers[Layer.LEFT][0], layers[Layer.BACK][n - 1]),
+        # UBR
+        (layers[Layer.UP][n - 1], layers[Layer.BACK][0], layers[Layer.RIGHT][n - 1]),
+        # DFL
+        (layers[Layer.DOWN][0], layers[Layer.LEFT][n * n - 1], layers[Layer.FRONT][n * (n - 1)]),
+        # DFR
+        (layers[Layer.DOWN][n - 1], layers[Layer.FRONT][n * n - 1], layers[Layer.RIGHT][n * (n - 1)]),
+        # DBL
+        (layers[Layer.DOWN][n * (n - 1)], layers[Layer.BACK][n * n - 1], layers[Layer.LEFT][n * (n - 1)]),
+        # DBR
+        (layers[Layer.DOWN][n * n - 1], layers[Layer.RIGHT][n * n - 1], layers[Layer.BACK][n * (n - 1)]),
+    ]
+
+
+def get_edges(cube: Cube) -> list[tuple[Color, Color]]:
+    """
+    Returns a list of 12 edge tuples in canonical order (UF, UB, UL, UR, DF, DB, DL, DR, FL, FR, BL, BR).
+    Each tuple is (face1_color, face2_color) as defined by the sticker index table.
+
+    :param cube: The Cube instance
+    :return: List of 12 edge color tuples
+    """
+
+    layers = cube.layers
+    size = cube.size
+
+    # Define location of middle edges of an odd sized cube
+    top_edge = size // 2
+    left_edge = size * (size // 2)
+    right_edge = size * (size // 2) + size - 1
+    bottom_edge = size * size - size // 2 - 1
+
+    return [
+        # UF
+        (layers[Layer.UP][bottom_edge], layers[Layer.FRONT][top_edge]),
+        # UB
+        (layers[Layer.UP][top_edge], layers[Layer.BACK][top_edge]),
+        # UL
+        (layers[Layer.UP][left_edge], layers[Layer.LEFT][top_edge]),
+        # UR
+        (layers[Layer.UP][right_edge], layers[Layer.RIGHT][top_edge]),
+        # DF
+        (layers[Layer.DOWN][top_edge], layers[Layer.FRONT][bottom_edge]),
+        # DB
+        (layers[Layer.DOWN][bottom_edge], layers[Layer.BACK][bottom_edge]),
+        # DL
+        (layers[Layer.DOWN][left_edge], layers[Layer.LEFT][bottom_edge]),
+        # DR
+        (layers[Layer.DOWN][right_edge], layers[Layer.RIGHT][bottom_edge]),
+        # FL
+        (layers[Layer.FRONT][left_edge], layers[Layer.LEFT][right_edge]),
+        # FR
+        (layers[Layer.FRONT][right_edge], layers[Layer.RIGHT][left_edge]),
+        # BL
+        (layers[Layer.BACK][right_edge], layers[Layer.LEFT][left_edge]),
+        # BR
+        (layers[Layer.BACK][left_edge], layers[Layer.RIGHT][right_edge]),
+    ]

--- a/solver/test/validator/validator_test.py
+++ b/solver/test/validator/validator_test.py
@@ -11,14 +11,45 @@ from rubik_cube_solver.validator.validator import Validator
 
 
 class TestValidatorValidate:
+    def test_success_3x3(self, validator: Validator) -> None:
+        """
+        Test that validate calls all 9 check methods exactly once for a 3x3 cube.
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        cube = Cube(3)
+        with (
+            patch.object(validator, "_check_size") as mock_check_size,
+            patch.object(validator, "_check_color_count") as mock_check_color_count,
+            patch.object(validator, "_check_corner_validity") as mock_check_corner_validity,
+            patch.object(validator, "_check_corner_orientation") as mock_check_corner_orientation,
+            patch.object(validator, "_check_corner_chirality") as mock_check_corner_chirality,
+            patch.object(validator, "_check_center_uniqueness") as mock_check_center_uniqueness,
+            patch.object(validator, "_check_edge_validity") as mock_check_edge_validity,
+            patch.object(validator, "_check_edge_flip_parity") as mock_check_edge_flip_parity,
+            patch.object(validator, "_check_permutation_parity") as mock_check_permutation_parity,
+        ):
+            validator.validate(cube)
+            mock_check_size.assert_called_once_with(cube)
+            mock_check_color_count.assert_called_once_with(cube)
+            mock_check_corner_validity.assert_called_once_with(cube)
+            mock_check_corner_orientation.assert_called_once_with(cube)
+            mock_check_corner_chirality.assert_called_once_with(cube)
+            mock_check_center_uniqueness.assert_called_once_with(cube)
+            mock_check_edge_validity.assert_called_once_with(cube)
+            mock_check_edge_flip_parity.assert_called_once_with(cube)
+            mock_check_permutation_parity.assert_called_once_with(cube)
+
     # fmt: off
     @pytest.mark.parametrize(
-        "cube_size", [2, 3, 4, 5]
+        "cube_size", [2, 4, 5]
     )
     # fmt: on
-    def test_success(self, validator: Validator, cube_size: int) -> None:
+    def test_success_non_3x3(self, validator: Validator, cube_size: int) -> None:
         """
-        Test that validate calls both private check methods exactly once.
+        Test that validate does not call the 4 new 3x3-specific check methods for non-3x3 cubes.
 
         :param validator: Fixture of a Validator instance
         :param cube_size: The size of the cube to validate
@@ -32,6 +63,10 @@ class TestValidatorValidate:
             patch.object(validator, "_check_corner_validity") as mock_check_corner_validity,
             patch.object(validator, "_check_corner_orientation") as mock_check_corner_orientation,
             patch.object(validator, "_check_corner_chirality") as mock_check_corner_chirality,
+            patch.object(validator, "_check_center_uniqueness") as mock_check_center_uniqueness,
+            patch.object(validator, "_check_edge_validity") as mock_check_edge_validity,
+            patch.object(validator, "_check_edge_flip_parity") as mock_check_edge_flip_parity,
+            patch.object(validator, "_check_permutation_parity") as mock_check_permutation_parity,
         ):
             validator.validate(cube)
             mock_check_size.assert_called_once_with(cube)
@@ -39,6 +74,128 @@ class TestValidatorValidate:
             mock_check_corner_validity.assert_called_once_with(cube)
             mock_check_corner_orientation.assert_called_once_with(cube)
             mock_check_corner_chirality.assert_called_once_with(cube)
+            mock_check_center_uniqueness.assert_not_called()
+            mock_check_edge_validity.assert_not_called()
+            mock_check_edge_flip_parity.assert_not_called()
+            mock_check_permutation_parity.assert_not_called()
+
+    def test_check_center_uniqueness_exception(self, validator: Validator) -> None:
+        """
+        Test that validate propagates ValueError from _check_center_uniqueness and does not call subsequent checks.
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        cube = Cube(3)
+        with (
+            patch.object(validator, "_check_size"),
+            patch.object(validator, "_check_color_count"),
+            patch.object(validator, "_check_corner_validity"),
+            patch.object(validator, "_check_corner_orientation"),
+            patch.object(validator, "_check_corner_chirality"),
+            patch.object(
+                validator,
+                "_check_center_uniqueness",
+                side_effect=ValueError("Duplicate center piece."),
+            ) as mock_check_center_uniqueness,
+            patch.object(validator, "_check_edge_validity") as mock_check_edge_validity,
+            patch.object(validator, "_check_edge_flip_parity") as mock_check_edge_flip_parity,
+            patch.object(validator, "_check_permutation_parity") as mock_check_permutation_parity,
+        ):
+            with pytest.raises(ValueError, match="Duplicate center piece"):
+                validator.validate(cube)
+            mock_check_center_uniqueness.assert_called_once_with(cube)
+            mock_check_edge_validity.assert_not_called()
+            mock_check_edge_flip_parity.assert_not_called()
+            mock_check_permutation_parity.assert_not_called()
+
+    def test_check_edge_validity_exception(self, validator: Validator) -> None:
+        """
+        Test that validate propagates ValueError from _check_edge_validity and does not call subsequent checks.
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        cube = Cube(3)
+        with (
+            patch.object(validator, "_check_size"),
+            patch.object(validator, "_check_color_count"),
+            patch.object(validator, "_check_corner_validity"),
+            patch.object(validator, "_check_corner_orientation"),
+            patch.object(validator, "_check_corner_chirality"),
+            patch.object(validator, "_check_center_uniqueness"),
+            patch.object(
+                validator,
+                "_check_edge_validity",
+                side_effect=ValueError("Invalid edge piece."),
+            ) as mock_check_edge_validity,
+            patch.object(validator, "_check_edge_flip_parity") as mock_check_edge_flip_parity,
+            patch.object(validator, "_check_permutation_parity") as mock_check_permutation_parity,
+        ):
+            with pytest.raises(ValueError, match="Invalid edge piece"):
+                validator.validate(cube)
+            mock_check_edge_validity.assert_called_once_with(cube)
+            mock_check_edge_flip_parity.assert_not_called()
+            mock_check_permutation_parity.assert_not_called()
+
+    def test_check_edge_flip_parity_exception(self, validator: Validator) -> None:
+        """
+        Test that validate propagates ValueError from _check_edge_flip_parity and does not call subsequent checks.
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        cube = Cube(3)
+        with (
+            patch.object(validator, "_check_size"),
+            patch.object(validator, "_check_color_count"),
+            patch.object(validator, "_check_corner_validity"),
+            patch.object(validator, "_check_corner_orientation"),
+            patch.object(validator, "_check_corner_chirality"),
+            patch.object(validator, "_check_center_uniqueness"),
+            patch.object(validator, "_check_edge_validity"),
+            patch.object(
+                validator,
+                "_check_edge_flip_parity",
+                side_effect=ValueError("Invalid edge flip parity."),
+            ) as mock_check_edge_flip_parity,
+            patch.object(validator, "_check_permutation_parity") as mock_check_permutation_parity,
+        ):
+            with pytest.raises(ValueError, match="Invalid edge flip parity"):
+                validator.validate(cube)
+            mock_check_edge_flip_parity.assert_called_once_with(cube)
+            mock_check_permutation_parity.assert_not_called()
+
+    def test_check_permutation_parity_exception(self, validator: Validator) -> None:
+        """
+        Test that validate propagates ValueError from _check_permutation_parity.
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        cube = Cube(3)
+        with (
+            patch.object(validator, "_check_size"),
+            patch.object(validator, "_check_color_count"),
+            patch.object(validator, "_check_corner_validity"),
+            patch.object(validator, "_check_corner_orientation"),
+            patch.object(validator, "_check_corner_chirality"),
+            patch.object(validator, "_check_center_uniqueness"),
+            patch.object(validator, "_check_edge_validity"),
+            patch.object(validator, "_check_edge_flip_parity"),
+            patch.object(
+                validator,
+                "_check_permutation_parity",
+                side_effect=ValueError("Invalid permutation parity."),
+            ) as mock_check_permutation_parity,
+        ):
+            with pytest.raises(ValueError, match="Invalid permutation parity"):
+                validator.validate(cube)
+            mock_check_permutation_parity.assert_called_once_with(cube)
 
     def test_check_size_exception(self, validator: Validator) -> None:
         """
@@ -491,3 +648,297 @@ class TestValidatorCheckCornerChirality:
         with patch.object(Validator, "_get_corners", return_value=corners):
             with pytest.raises(ValueError, match="Invalid corner chirality"):
                 validator._check_corner_chirality(cube)
+
+
+class TestValidatorGetEdges:
+    def test_success(self, validator: Validator) -> None:
+        """
+        Test that _get_edges returns 12 edge tuples with correct sticker colors for a solved 3x3 cube.
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        cube = Cube(3)
+        edges = validator._get_edges(cube)
+
+        assert len(edges) == 12
+        for edge in edges:
+            assert isinstance(edge, tuple)
+            assert len(edge) == 2
+            assert isinstance(edge[0], Color)
+            assert isinstance(edge[1], Color)
+
+        # UF edge should be (WHITE, GREEN) for a solved cube
+        assert edges[0] == (Color.WHITE, Color.GREEN)
+
+
+class TestValidatorCheckCenterUniqueness:
+    def test_success(self, validator: Validator) -> None:
+        """
+        Test that _check_center_uniqueness does not raise for a solved 3x3 cube.
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        cube = Cube(3)
+        validator._check_center_uniqueness(cube)
+
+    def test_exception_duplicate_center(self, validator: Validator) -> None:
+        """
+        Test that _check_center_uniqueness raises ValueError when two faces share the same center color.
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        # fmt: off
+        cube = Cube(
+            size=3,
+            layers={
+                Layer.UP:    [Color.WHITE,  Color.WHITE,  Color.WHITE,
+                              Color.WHITE,  Color.WHITE,  Color.WHITE,
+                              Color.WHITE,  Color.WHITE,  Color.WHITE],
+                Layer.DOWN:  [Color.WHITE,  Color.WHITE,  Color.WHITE,
+                              Color.WHITE,  Color.WHITE,  Color.WHITE,
+                              Color.WHITE,  Color.WHITE,  Color.WHITE],
+                Layer.LEFT:  [Color.ORANGE, Color.ORANGE, Color.ORANGE,
+                              Color.ORANGE, Color.ORANGE, Color.ORANGE,
+                              Color.ORANGE, Color.ORANGE, Color.ORANGE],
+                Layer.RIGHT: [Color.RED,    Color.RED,    Color.RED,
+                              Color.RED,    Color.RED,    Color.RED,
+                              Color.RED,    Color.RED,    Color.RED],
+                Layer.FRONT: [Color.GREEN,  Color.GREEN,  Color.GREEN,
+                              Color.GREEN,  Color.GREEN,  Color.GREEN,
+                              Color.GREEN,  Color.GREEN,  Color.GREEN],
+                Layer.BACK:  [Color.BLUE,   Color.BLUE,   Color.BLUE,
+                              Color.BLUE,   Color.BLUE,   Color.BLUE,
+                              Color.BLUE,   Color.BLUE,   Color.BLUE],
+            }
+        )
+        # fmt: on
+        with pytest.raises(ValueError, match="Duplicate center piece"):
+            validator._check_center_uniqueness(cube)
+
+
+class TestValidatorCheckEdgeValidity:
+    def test_success(self, validator: Validator) -> None:
+        """
+        Test that _check_edge_validity does not raise when all 12 edges are valid and distinct.
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        cube = Cube(3)
+        edges = [
+            (Color.WHITE, Color.GREEN),
+            (Color.WHITE, Color.BLUE),
+            (Color.WHITE, Color.ORANGE),
+            (Color.WHITE, Color.RED),
+            (Color.YELLOW, Color.GREEN),
+            (Color.YELLOW, Color.BLUE),
+            (Color.YELLOW, Color.ORANGE),
+            (Color.YELLOW, Color.RED),
+            (Color.GREEN, Color.ORANGE),
+            (Color.GREEN, Color.RED),
+            (Color.BLUE, Color.ORANGE),
+            (Color.BLUE, Color.RED),
+        ]
+        with patch.object(Validator, "_get_edges", return_value=edges):
+            validator._check_edge_validity(cube)
+
+    def test_exception_invalid_edge(self, validator: Validator) -> None:
+        """
+        Test that _check_edge_validity raises ValueError when one edge has an impossible color combination.
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        cube = Cube(3)
+        edges = [
+            (Color.WHITE, Color.YELLOW),  # invalid: opposite faces cannot share an edge
+            (Color.WHITE, Color.BLUE),
+            (Color.WHITE, Color.ORANGE),
+            (Color.WHITE, Color.RED),
+            (Color.YELLOW, Color.GREEN),
+            (Color.YELLOW, Color.BLUE),
+            (Color.YELLOW, Color.ORANGE),
+            (Color.YELLOW, Color.RED),
+            (Color.GREEN, Color.ORANGE),
+            (Color.GREEN, Color.RED),
+            (Color.BLUE, Color.ORANGE),
+            (Color.BLUE, Color.RED),
+        ]
+        with patch.object(Validator, "_get_edges", return_value=edges):
+            with pytest.raises(ValueError, match="Invalid edge piece"):
+                validator._check_edge_validity(cube)
+
+    def test_exception_duplicate_edge(self, validator: Validator) -> None:
+        """
+        Test that _check_edge_validity raises ValueError when two edges have the same color set.
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        cube = Cube(3)
+        edges = [
+            (Color.WHITE, Color.GREEN),
+            (Color.WHITE, Color.GREEN),  # duplicate of first edge
+            (Color.WHITE, Color.ORANGE),
+            (Color.WHITE, Color.RED),
+            (Color.YELLOW, Color.GREEN),
+            (Color.YELLOW, Color.BLUE),
+            (Color.YELLOW, Color.ORANGE),
+            (Color.YELLOW, Color.RED),
+            (Color.GREEN, Color.ORANGE),
+            (Color.GREEN, Color.RED),
+            (Color.BLUE, Color.ORANGE),
+            (Color.BLUE, Color.RED),
+        ]
+        with patch.object(Validator, "_get_edges", return_value=edges):
+            with pytest.raises(ValueError, match="Duplicate edge piece"):
+                validator._check_edge_validity(cube)
+
+
+class TestValidatorCheckEdgeFlipParity:
+    def test_success(self, validator: Validator) -> None:
+        """
+        Test that _check_edge_flip_parity does not raise when all 12 edges are in oriented position (total = 0).
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        cube = Cube(3)
+        # All edges have the primary color in position 0 (orientation = 0, total = 0)
+        edges = [
+            (Color.WHITE, Color.GREEN),
+            (Color.WHITE, Color.BLUE),
+            (Color.WHITE, Color.ORANGE),
+            (Color.WHITE, Color.RED),
+            (Color.YELLOW, Color.GREEN),
+            (Color.YELLOW, Color.BLUE),
+            (Color.YELLOW, Color.ORANGE),
+            (Color.YELLOW, Color.RED),
+            (Color.GREEN, Color.ORANGE),
+            (Color.GREEN, Color.RED),
+            (Color.BLUE, Color.ORANGE),
+            (Color.BLUE, Color.RED),
+        ]
+        with patch.object(Validator, "_get_edges", return_value=edges):
+            validator._check_edge_flip_parity(cube)
+
+    def test_exception(self, validator: Validator) -> None:
+        """
+        Test that _check_edge_flip_parity raises ValueError when one edge is flipped (total = 1, which is odd).
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        cube = Cube(3)
+        # UF edge is flipped: GREEN is in position 0 instead of WHITE (orientation = 1, total = 1)
+        edges = [
+            (Color.GREEN, Color.WHITE),  # flipped UF edge
+            (Color.WHITE, Color.BLUE),
+            (Color.WHITE, Color.ORANGE),
+            (Color.WHITE, Color.RED),
+            (Color.YELLOW, Color.GREEN),
+            (Color.YELLOW, Color.BLUE),
+            (Color.YELLOW, Color.ORANGE),
+            (Color.YELLOW, Color.RED),
+            (Color.GREEN, Color.ORANGE),
+            (Color.GREEN, Color.RED),
+            (Color.BLUE, Color.ORANGE),
+            (Color.BLUE, Color.RED),
+        ]
+        with patch.object(Validator, "_get_edges", return_value=edges):
+            with pytest.raises(ValueError, match="Invalid edge flip parity"):
+                validator._check_edge_flip_parity(cube)
+
+
+class TestValidatorCheckPermutationParity:
+    def test_success(self, validator: Validator) -> None:
+        """
+        Test that _check_permutation_parity does not raise when corners and edges are both in solved order (both even).
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        cube = Cube(3)
+        corners = [
+            (Color.WHITE, Color.GREEN, Color.ORANGE),  # UFL
+            (Color.WHITE, Color.RED, Color.GREEN),  # UFR
+            (Color.WHITE, Color.ORANGE, Color.BLUE),  # UBL
+            (Color.WHITE, Color.BLUE, Color.RED),  # UBR
+            (Color.YELLOW, Color.ORANGE, Color.GREEN),  # DFL
+            (Color.YELLOW, Color.GREEN, Color.RED),  # DFR
+            (Color.YELLOW, Color.BLUE, Color.ORANGE),  # DBL
+            (Color.YELLOW, Color.RED, Color.BLUE),  # DBR
+        ]
+        edges = [
+            (Color.WHITE, Color.GREEN),
+            (Color.WHITE, Color.BLUE),
+            (Color.WHITE, Color.ORANGE),
+            (Color.WHITE, Color.RED),
+            (Color.YELLOW, Color.GREEN),
+            (Color.YELLOW, Color.BLUE),
+            (Color.YELLOW, Color.ORANGE),
+            (Color.YELLOW, Color.RED),
+            (Color.GREEN, Color.ORANGE),
+            (Color.GREEN, Color.RED),
+            (Color.BLUE, Color.ORANGE),
+            (Color.BLUE, Color.RED),
+        ]
+        with (
+            patch.object(Validator, "_get_corners", return_value=corners),
+            patch.object(Validator, "_get_edges", return_value=edges),
+        ):
+            validator._check_permutation_parity(cube)
+
+    def test_exception(self, validator: Validator) -> None:
+        """
+        Test that _check_permutation_parity raises ValueError when two corners are swapped (odd corner parity)
+        while edges remain in solved order (even parity).
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        cube = Cube(3)
+        # Swap UFL and UFR corners — this creates one inversion (odd corner parity)
+        corners = [
+            (Color.WHITE, Color.RED, Color.GREEN),  # UFR in UFL slot
+            (Color.WHITE, Color.GREEN, Color.ORANGE),  # UFL in UFR slot
+            (Color.WHITE, Color.ORANGE, Color.BLUE),  # UBL
+            (Color.WHITE, Color.BLUE, Color.RED),  # UBR
+            (Color.YELLOW, Color.ORANGE, Color.GREEN),  # DFL
+            (Color.YELLOW, Color.GREEN, Color.RED),  # DFR
+            (Color.YELLOW, Color.BLUE, Color.ORANGE),  # DBL
+            (Color.YELLOW, Color.RED, Color.BLUE),  # DBR
+        ]
+        edges = [
+            (Color.WHITE, Color.GREEN),
+            (Color.WHITE, Color.BLUE),
+            (Color.WHITE, Color.ORANGE),
+            (Color.WHITE, Color.RED),
+            (Color.YELLOW, Color.GREEN),
+            (Color.YELLOW, Color.BLUE),
+            (Color.YELLOW, Color.ORANGE),
+            (Color.YELLOW, Color.RED),
+            (Color.GREEN, Color.ORANGE),
+            (Color.GREEN, Color.RED),
+            (Color.BLUE, Color.ORANGE),
+            (Color.BLUE, Color.RED),
+        ]
+        with (
+            patch.object(Validator, "_get_corners", return_value=corners),
+            patch.object(Validator, "_get_edges", return_value=edges),
+        ):
+            with pytest.raises(ValueError, match="Invalid permutation parity"):
+                validator._check_permutation_parity(cube)

--- a/solver/test/validator/validator_test.py
+++ b/solver/test/validator/validator_test.py
@@ -11,15 +11,21 @@ from rubik_cube_solver.validator.validator import Validator
 
 
 class TestValidatorValidate:
-    def test_success_3x3(self, validator: Validator) -> None:
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size", [3, 5, 7]
+    )
+    # fmt: on
+    def test_success_odd(self, validator: Validator, cube_size: int) -> None:
         """
-        Test that validate calls all 9 check methods exactly once for a 3x3 cube.
+        Test that validate calls all 9 check methods exactly once for an odd sized cube.
 
         :param validator: Fixture of a Validator instance
+        :param cube_size: The size of the cube to validate
         :return: None
         """
 
-        cube = Cube(3)
+        cube = Cube(cube_size)
         with (
             patch.object(validator, "_check_size") as mock_check_size,
             patch.object(validator, "_check_color_count") as mock_check_color_count,
@@ -44,12 +50,12 @@ class TestValidatorValidate:
 
     # fmt: off
     @pytest.mark.parametrize(
-        "cube_size", [2, 4, 5]
+        "cube_size", [2, 4, 6]
     )
     # fmt: on
-    def test_success_non_3x3(self, validator: Validator, cube_size: int) -> None:
+    def test_success_even(self, validator: Validator, cube_size: int) -> None:
         """
-        Test that validate does not call the 4 new 3x3-specific check methods for non-3x3 cubes.
+        Test that validate does not call the specific check methods for odd sized cubes.
 
         :param validator: Fixture of a Validator instance
         :param cube_size: The size of the cube to validate
@@ -78,241 +84,6 @@ class TestValidatorValidate:
             mock_check_edge_validity.assert_not_called()
             mock_check_edge_flip_parity.assert_not_called()
             mock_check_permutation_parity.assert_not_called()
-
-    def test_check_center_uniqueness_exception(self, validator: Validator) -> None:
-        """
-        Test that validate propagates ValueError from _check_center_uniqueness and does not call subsequent checks.
-
-        :param validator: Fixture of a Validator instance
-        :return: None
-        """
-
-        cube = Cube(3)
-        with (
-            patch.object(validator, "_check_size"),
-            patch.object(validator, "_check_color_count"),
-            patch.object(validator, "_check_corner_validity"),
-            patch.object(validator, "_check_corner_orientation"),
-            patch.object(validator, "_check_corner_chirality"),
-            patch.object(
-                validator,
-                "_check_center_uniqueness",
-                side_effect=ValueError("Duplicate center piece."),
-            ) as mock_check_center_uniqueness,
-            patch.object(validator, "_check_edge_validity") as mock_check_edge_validity,
-            patch.object(validator, "_check_edge_flip_parity") as mock_check_edge_flip_parity,
-            patch.object(validator, "_check_permutation_parity") as mock_check_permutation_parity,
-        ):
-            with pytest.raises(ValueError, match="Duplicate center piece"):
-                validator.validate(cube)
-            mock_check_center_uniqueness.assert_called_once_with(cube)
-            mock_check_edge_validity.assert_not_called()
-            mock_check_edge_flip_parity.assert_not_called()
-            mock_check_permutation_parity.assert_not_called()
-
-    def test_check_edge_validity_exception(self, validator: Validator) -> None:
-        """
-        Test that validate propagates ValueError from _check_edge_validity and does not call subsequent checks.
-
-        :param validator: Fixture of a Validator instance
-        :return: None
-        """
-
-        cube = Cube(3)
-        with (
-            patch.object(validator, "_check_size"),
-            patch.object(validator, "_check_color_count"),
-            patch.object(validator, "_check_corner_validity"),
-            patch.object(validator, "_check_corner_orientation"),
-            patch.object(validator, "_check_corner_chirality"),
-            patch.object(validator, "_check_center_uniqueness"),
-            patch.object(
-                validator,
-                "_check_edge_validity",
-                side_effect=ValueError("Invalid edge piece."),
-            ) as mock_check_edge_validity,
-            patch.object(validator, "_check_edge_flip_parity") as mock_check_edge_flip_parity,
-            patch.object(validator, "_check_permutation_parity") as mock_check_permutation_parity,
-        ):
-            with pytest.raises(ValueError, match="Invalid edge piece"):
-                validator.validate(cube)
-            mock_check_edge_validity.assert_called_once_with(cube)
-            mock_check_edge_flip_parity.assert_not_called()
-            mock_check_permutation_parity.assert_not_called()
-
-    def test_check_edge_flip_parity_exception(self, validator: Validator) -> None:
-        """
-        Test that validate propagates ValueError from _check_edge_flip_parity and does not call subsequent checks.
-
-        :param validator: Fixture of a Validator instance
-        :return: None
-        """
-
-        cube = Cube(3)
-        with (
-            patch.object(validator, "_check_size"),
-            patch.object(validator, "_check_color_count"),
-            patch.object(validator, "_check_corner_validity"),
-            patch.object(validator, "_check_corner_orientation"),
-            patch.object(validator, "_check_corner_chirality"),
-            patch.object(validator, "_check_center_uniqueness"),
-            patch.object(validator, "_check_edge_validity"),
-            patch.object(
-                validator,
-                "_check_edge_flip_parity",
-                side_effect=ValueError("Invalid edge flip parity."),
-            ) as mock_check_edge_flip_parity,
-            patch.object(validator, "_check_permutation_parity") as mock_check_permutation_parity,
-        ):
-            with pytest.raises(ValueError, match="Invalid edge flip parity"):
-                validator.validate(cube)
-            mock_check_edge_flip_parity.assert_called_once_with(cube)
-            mock_check_permutation_parity.assert_not_called()
-
-    def test_check_permutation_parity_exception(self, validator: Validator) -> None:
-        """
-        Test that validate propagates ValueError from _check_permutation_parity.
-
-        :param validator: Fixture of a Validator instance
-        :return: None
-        """
-
-        cube = Cube(3)
-        with (
-            patch.object(validator, "_check_size"),
-            patch.object(validator, "_check_color_count"),
-            patch.object(validator, "_check_corner_validity"),
-            patch.object(validator, "_check_corner_orientation"),
-            patch.object(validator, "_check_corner_chirality"),
-            patch.object(validator, "_check_center_uniqueness"),
-            patch.object(validator, "_check_edge_validity"),
-            patch.object(validator, "_check_edge_flip_parity"),
-            patch.object(
-                validator,
-                "_check_permutation_parity",
-                side_effect=ValueError("Invalid permutation parity."),
-            ) as mock_check_permutation_parity,
-        ):
-            with pytest.raises(ValueError, match="Invalid permutation parity"):
-                validator.validate(cube)
-            mock_check_permutation_parity.assert_called_once_with(cube)
-
-    def test_check_size_exception(self, validator: Validator) -> None:
-        """
-        Test that validate propagates ValueError from _check_size and does not call _check_color_count.
-
-        :param validator: Fixture of a Validator instance
-        :return: None
-        """
-
-        cube = Cube(1)
-        with (
-            patch.object(
-                validator, "_check_size", side_effect=ValueError("Cube size must be at least 2.")
-            ) as mock_check_size,
-            patch.object(validator, "_check_color_count") as mock_check_color_count,
-        ):
-            with pytest.raises(ValueError, match="Cube size must be at least 2."):
-                validator.validate(cube)
-            mock_check_size.assert_called_once_with(cube)
-            mock_check_color_count.assert_not_called()
-
-    def test_check_color_count_exception(self, validator: Validator) -> None:
-        """
-        Test that validate propagates ValueError from _check_color_count and still calls _check_size.
-
-        :param validator: Fixture of a Validator instance
-        :return: None
-        """
-
-        cube = Cube(2)
-        with (
-            patch.object(validator, "_check_size") as mock_check_size,
-            patch.object(
-                validator,
-                "_check_color_count",
-                side_effect=ValueError("Invalid color count for WHITE: expected 4, got 3."),
-            ) as mock_check_color_count,
-        ):
-            with pytest.raises(ValueError, match=r"Invalid color count for WHITE: expected 4, got 3\."):
-                validator.validate(cube)
-            mock_check_size.assert_called_once_with(cube)
-            mock_check_color_count.assert_called_once_with(cube)
-
-    def test_check_corner_validity_exception(self, validator: Validator) -> None:
-        """
-        Test that validate propagates ValueError from _check_corner_validity.
-
-        :param validator: Fixture of a Validator instance
-        :return: None
-        """
-
-        cube = Cube(2)
-        with (
-            patch.object(validator, "_check_size"),
-            patch.object(validator, "_check_color_count"),
-            patch.object(
-                validator,
-                "_check_corner_validity",
-                side_effect=ValueError("Invalid corner piece."),
-            ) as mock_check_corner_validity,
-            patch.object(validator, "_check_corner_orientation") as mock_check_corner_orientation,
-            patch.object(validator, "_check_corner_chirality") as mock_check_corner_chirality,
-        ):
-            with pytest.raises(ValueError, match="Invalid corner piece"):
-                validator.validate(cube)
-            mock_check_corner_validity.assert_called_once_with(cube)
-            mock_check_corner_orientation.assert_not_called()
-            mock_check_corner_chirality.assert_not_called()
-
-    def test_check_corner_orientation_exception(self, validator: Validator) -> None:
-        """
-        Test that validate propagates ValueError from _check_corner_orientation.
-
-        :param validator: Fixture of a Validator instance
-        :return: None
-        """
-
-        cube = Cube(2)
-        with (
-            patch.object(validator, "_check_size"),
-            patch.object(validator, "_check_color_count"),
-            patch.object(validator, "_check_corner_validity"),
-            patch.object(
-                validator,
-                "_check_corner_orientation",
-                side_effect=ValueError("Invalid corner orientation parity."),
-            ) as mock_check_corner_orientation,
-            patch.object(validator, "_check_corner_chirality") as mock_check_corner_chirality,
-        ):
-            with pytest.raises(ValueError, match="Invalid corner orientation parity"):
-                validator.validate(cube)
-            mock_check_corner_orientation.assert_called_once_with(cube)
-            mock_check_corner_chirality.assert_not_called()
-
-    def test_check_corner_chirality_exception(self, validator: Validator) -> None:
-        """
-        Test that validate propagates ValueError from _check_corner_chirality.
-
-        :param validator: Fixture of a Validator instance
-        :return: None
-        """
-
-        cube = Cube(2)
-        with (
-            patch.object(validator, "_check_size"),
-            patch.object(validator, "_check_color_count"),
-            patch.object(validator, "_check_corner_validity"),
-            patch.object(validator, "_check_corner_orientation"),
-            patch.object(
-                validator,
-                "_check_corner_chirality",
-                side_effect=ValueError("Invalid corner chirality."),
-            ) as mock_check_corner_chirality,
-        ):
-            with pytest.raises(ValueError, match="Invalid corner chirality"):
-                validator.validate(cube)
-            mock_check_corner_chirality.assert_called_once_with(cube)
 
 
 class TestValidatorCheckSize:
@@ -425,24 +196,6 @@ class TestValidatorCheckColorCount:
             validator._check_color_count(cube)
 
 
-class TestValidatorGetCorners:
-    def test_success(self, validator: Validator) -> None:
-        """
-        Test that _get_corners returns the expected corners.
-
-        :param validator: Fixture of a Validator instance
-        :return: None
-        """
-
-        cube = Cube(3)
-        corners = validator._get_corners(cube)
-
-        assert len(corners) == 8
-        for corner in corners:
-            assert isinstance(corner, tuple)
-            assert len(corner) == 3
-
-
 class TestValidatorCheckCornerValidity:
     def test_success(self, validator: Validator) -> None:
         """
@@ -456,14 +209,14 @@ class TestValidatorCheckCornerValidity:
         corners = [
             (Color.WHITE, Color.GREEN, Color.ORANGE),  # UFL
             (Color.WHITE, Color.RED, Color.GREEN),  # UFR
-            (Color.WHITE, Color.ORANGE, Color.BLUE),  # UBL  (canonical: WHITE, ORANGE, BLUE)
+            (Color.WHITE, Color.ORANGE, Color.BLUE),  # UBL
             (Color.WHITE, Color.BLUE, Color.RED),  # UBR
             (Color.YELLOW, Color.ORANGE, Color.GREEN),  # DFL
             (Color.YELLOW, Color.GREEN, Color.RED),  # DFR
             (Color.YELLOW, Color.BLUE, Color.ORANGE),  # DBL
             (Color.YELLOW, Color.RED, Color.BLUE),  # DBR
         ]
-        with patch.object(Validator, "_get_corners", return_value=corners):
+        with patch("rubik_cube_solver.validator.validator.get_corners", return_value=corners):
             validator._check_corner_validity(cube)
 
     def test_exception_invalid_corner(self, validator: Validator) -> None:
@@ -486,7 +239,7 @@ class TestValidatorCheckCornerValidity:
             (Color.YELLOW, Color.BLUE, Color.ORANGE),
             (Color.YELLOW, Color.RED, Color.BLUE),
         ]
-        with patch.object(Validator, "_get_corners", return_value=corners):
+        with patch("rubik_cube_solver.validator.validator.get_corners", return_value=corners):
             with pytest.raises(ValueError, match="Invalid corner piece"):
                 validator._check_corner_validity(cube)
 
@@ -510,7 +263,7 @@ class TestValidatorCheckCornerValidity:
             (Color.YELLOW, Color.BLUE, Color.ORANGE),
             (Color.YELLOW, Color.RED, Color.BLUE),
         ]
-        with patch.object(Validator, "_get_corners", return_value=corners):
+        with patch("rubik_cube_solver.validator.validator.get_corners", return_value=corners):
             with pytest.raises(ValueError, match="Duplicate corner piece"):
                 validator._check_corner_validity(cube)
 
@@ -536,7 +289,7 @@ class TestValidatorCheckCornerOrientation:
             (Color.YELLOW, Color.BLUE, Color.ORANGE),
             (Color.YELLOW, Color.RED, Color.BLUE),
         ]
-        with patch.object(Validator, "_get_corners", return_value=corners):
+        with patch("rubik_cube_solver.validator.validator.get_corners", return_value=corners):
             validator._check_corner_orientation(cube)
 
     # fmt: off
@@ -596,7 +349,7 @@ class TestValidatorCheckCornerOrientation:
         """
 
         cube = Cube(3)
-        with patch.object(Validator, "_get_corners", return_value=corners):
+        with patch("rubik_cube_solver.validator.validator.get_corners", return_value=corners):
             with pytest.raises(ValueError, match=exception):
                 validator._check_corner_orientation(cube)
 
@@ -622,7 +375,7 @@ class TestValidatorCheckCornerChirality:
             (Color.YELLOW, Color.BLUE, Color.ORANGE),  # canonical for {Y,B,O}
             (Color.YELLOW, Color.RED, Color.BLUE),  # canonical for {Y,B,R}
         ]
-        with patch.object(Validator, "_get_corners", return_value=corners):
+        with patch("rubik_cube_solver.validator.validator.get_corners", return_value=corners):
             validator._check_corner_chirality(cube)
 
     def test_exception(self, validator: Validator) -> None:
@@ -645,93 +398,142 @@ class TestValidatorCheckCornerChirality:
             (Color.YELLOW, Color.BLUE, Color.ORANGE),
             (Color.YELLOW, Color.RED, Color.BLUE),
         ]
-        with patch.object(Validator, "_get_corners", return_value=corners):
+        with patch("rubik_cube_solver.validator.validator.get_corners", return_value=corners):
             with pytest.raises(ValueError, match="Invalid corner chirality"):
                 validator._check_corner_chirality(cube)
 
 
-class TestValidatorGetEdges:
-    def test_success(self, validator: Validator) -> None:
-        """
-        Test that _get_edges returns 12 edge tuples with correct sticker colors for a solved 3x3 cube.
-
-        :param validator: Fixture of a Validator instance
-        :return: None
-        """
-
-        cube = Cube(3)
-        edges = validator._get_edges(cube)
-
-        assert len(edges) == 12
-        for edge in edges:
-            assert isinstance(edge, tuple)
-            assert len(edge) == 2
-            assert isinstance(edge[0], Color)
-            assert isinstance(edge[1], Color)
-
-        # UF edge should be (WHITE, GREEN) for a solved cube
-        assert edges[0] == (Color.WHITE, Color.GREEN)
-
-
 class TestValidatorCheckCenterUniqueness:
-    def test_success(self, validator: Validator) -> None:
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size", [3, 5]
+    )
+    # fmt: on
+    def test_success(self, validator: Validator, cube_size: int) -> None:
         """
-        Test that _check_center_uniqueness does not raise for a solved 3x3 cube.
+        Test that _check_center_uniqueness does not raise for a solved odd sized cube.
 
         :param validator: Fixture of a Validator instance
+        :param cube_size: The size of the cube to validate
         :return: None
         """
 
-        cube = Cube(3)
+        cube = Cube(cube_size)
         validator._check_center_uniqueness(cube)
 
-    def test_exception_duplicate_center(self, validator: Validator) -> None:
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size, layers",
+        [
+            (3, {
+                Layer.UP: [Color.WHITE] * 9,
+                Layer.DOWN: [Color.WHITE] * 9,  # duplicate of UP center color
+                Layer.LEFT: [Color.ORANGE] * 9,
+                Layer.RIGHT: [Color.RED] * 9,
+                Layer.FRONT: [Color.GREEN] * 9,
+                Layer.BACK: [Color.BLUE] * 9,
+            }),
+            (5, {
+                Layer.UP: [Color.WHITE] * 25,
+                Layer.DOWN: [Color.YELLOW] * 25,
+                Layer.LEFT: [Color.ORANGE] * 25,
+                Layer.RIGHT: [Color.ORANGE] * 25,  # duplicate of LEFT center color
+                Layer.FRONT: [Color.GREEN] * 25,
+                Layer.BACK: [Color.BLUE] * 25,
+            }),
+        ]
+    )
+    # fmt: on
+    def test_exception_duplicate_center(
+        self, validator: Validator, cube_size: int, layers: dict[Layer, list[Color]]
+    ) -> None:
         """
         Test that _check_center_uniqueness raises ValueError when two faces share the same center color.
 
         :param validator: Fixture of a Validator instance
+        :param cube_size: The size of the cube to validate
+        :param layers: Layer configuration for the cube with duplicate center colors
         :return: None
         """
 
-        # fmt: off
-        cube = Cube(
-            size=3,
-            layers={
-                Layer.UP:    [Color.WHITE,  Color.WHITE,  Color.WHITE,
-                              Color.WHITE,  Color.WHITE,  Color.WHITE,
-                              Color.WHITE,  Color.WHITE,  Color.WHITE],
-                Layer.DOWN:  [Color.WHITE,  Color.WHITE,  Color.WHITE,
-                              Color.WHITE,  Color.WHITE,  Color.WHITE,
-                              Color.WHITE,  Color.WHITE,  Color.WHITE],
-                Layer.LEFT:  [Color.ORANGE, Color.ORANGE, Color.ORANGE,
-                              Color.ORANGE, Color.ORANGE, Color.ORANGE,
-                              Color.ORANGE, Color.ORANGE, Color.ORANGE],
-                Layer.RIGHT: [Color.RED,    Color.RED,    Color.RED,
-                              Color.RED,    Color.RED,    Color.RED,
-                              Color.RED,    Color.RED,    Color.RED],
-                Layer.FRONT: [Color.GREEN,  Color.GREEN,  Color.GREEN,
-                              Color.GREEN,  Color.GREEN,  Color.GREEN,
-                              Color.GREEN,  Color.GREEN,  Color.GREEN],
-                Layer.BACK:  [Color.BLUE,   Color.BLUE,   Color.BLUE,
-                              Color.BLUE,   Color.BLUE,   Color.BLUE,
-                              Color.BLUE,   Color.BLUE,   Color.BLUE],
-            }
-        )
-        # fmt: on
+        cube = Cube(cube_size, layers)
         with pytest.raises(ValueError, match="Duplicate center piece"):
             validator._check_center_uniqueness(cube)
 
 
+class TestValidatorCheckCenterOpposites:
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size", [3, 5]
+    )
+    # fmt: on
+    def test_success(self, validator: Validator, cube_size: int) -> None:
+        """
+        Test that _check_center_opposites does not raise for a solved 3x3 cube.
+
+        :param validator: Fixture of a Validator instance
+        :param cube_size: The size of the cube to validate
+        :return: None
+        """
+
+        cube = Cube(cube_size)
+        validator._check_center_opposites(cube)
+
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size, layers",
+        [
+            (3, {
+                Layer.UP: [Color.WHITE] * 9,
+                Layer.DOWN: [Color.ORANGE] * 9,  # incorrect opposite color of UP, must be YELLOW
+                Layer.LEFT: [Color.YELLOW] * 9,  # incorrect opposite color of RIGHT, must be ORANGE
+                Layer.RIGHT: [Color.RED] * 9,
+                Layer.FRONT: [Color.GREEN] * 9,
+                Layer.BACK: [Color.BLUE] * 9,
+            }),
+            (5, {
+                Layer.UP: [Color.WHITE] * 25,
+                Layer.DOWN: [Color.YELLOW] * 25,
+                Layer.LEFT: [Color.ORANGE] * 25,
+                Layer.RIGHT: [Color.GREEN] * 25,  # incorrect opposite color of LEFT, must be RED
+                Layer.FRONT: [Color.RED] * 25,  # incorrect opposite color of BACK, must be GREEN
+                Layer.BACK: [Color.BLUE] * 25,
+            }),
+        ]
+    )
+    # fmt: on
+    def test_exception_incorrect_opposite(
+        self, validator: Validator, cube_size: int, layers: dict[Layer, list[Color]]
+    ) -> None:
+        """
+        Test that _check_center_opposites raises ValueError when opposite color is wrong.
+
+        :param validator: Fixture of a Validator instance
+        :param cube_size: The size of the cube to validate
+        :param layers: Layer configuration for the cube with incorrect opposite colors
+        """
+
+        cube = Cube(cube_size, layers)
+        with pytest.raises(ValueError, match="Invalid opposite color"):
+            validator._check_center_opposites(cube)
+
+
 class TestValidatorCheckEdgeValidity:
-    def test_success(self, validator: Validator) -> None:
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size", [3, 5]
+    )
+    # fmt: on
+    def test_success(self, validator: Validator, cube_size: int) -> None:
         """
         Test that _check_edge_validity does not raise when all 12 edges are valid and distinct.
 
         :param validator: Fixture of a Validator instance
+        :param cube_size: The size of the cube to validate
         :return: None
         """
 
-        cube = Cube(3)
+        cube = Cube(cube_size)
         edges = [
             (Color.WHITE, Color.GREEN),
             (Color.WHITE, Color.BLUE),
@@ -746,10 +548,15 @@ class TestValidatorCheckEdgeValidity:
             (Color.BLUE, Color.ORANGE),
             (Color.BLUE, Color.RED),
         ]
-        with patch.object(Validator, "_get_edges", return_value=edges):
+        with patch("rubik_cube_solver.validator.validator.get_edges", return_value=edges):
             validator._check_edge_validity(cube)
 
-    def test_exception_invalid_edge(self, validator: Validator) -> None:
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size", [3, 5]
+    )
+    # fmt: on
+    def test_exception_invalid_edge(self, validator: Validator, cube_size: int) -> None:
         """
         Test that _check_edge_validity raises ValueError when one edge has an impossible color combination.
 
@@ -757,7 +564,7 @@ class TestValidatorCheckEdgeValidity:
         :return: None
         """
 
-        cube = Cube(3)
+        cube = Cube(cube_size)
         edges = [
             (Color.WHITE, Color.YELLOW),  # invalid: opposite faces cannot share an edge
             (Color.WHITE, Color.BLUE),
@@ -772,19 +579,25 @@ class TestValidatorCheckEdgeValidity:
             (Color.BLUE, Color.ORANGE),
             (Color.BLUE, Color.RED),
         ]
-        with patch.object(Validator, "_get_edges", return_value=edges):
+        with patch("rubik_cube_solver.validator.validator.get_edges", return_value=edges):
             with pytest.raises(ValueError, match="Invalid edge piece"):
                 validator._check_edge_validity(cube)
 
-    def test_exception_duplicate_edge(self, validator: Validator) -> None:
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size", [3, 5]
+    )
+    # fmt: on
+    def test_exception_duplicate_edge(self, validator: Validator, cube_size: int) -> None:
         """
         Test that _check_edge_validity raises ValueError when two edges have the same color set.
 
         :param validator: Fixture of a Validator instance
+        :param cube_size: The size of the cube to validate
         :return: None
         """
 
-        cube = Cube(3)
+        cube = Cube(cube_size)
         edges = [
             (Color.WHITE, Color.GREEN),
             (Color.WHITE, Color.GREEN),  # duplicate of first edge
@@ -799,22 +612,27 @@ class TestValidatorCheckEdgeValidity:
             (Color.BLUE, Color.ORANGE),
             (Color.BLUE, Color.RED),
         ]
-        with patch.object(Validator, "_get_edges", return_value=edges):
+        with patch("rubik_cube_solver.validator.validator.get_edges", return_value=edges):
             with pytest.raises(ValueError, match="Duplicate edge piece"):
                 validator._check_edge_validity(cube)
 
 
 class TestValidatorCheckEdgeFlipParity:
-    def test_success(self, validator: Validator) -> None:
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size", [3, 5]
+    )
+    # fmt: on
+    def test_success(self, validator: Validator, cube_size: int) -> None:
         """
-        Test that _check_edge_flip_parity does not raise when all 12 edges are in oriented position (total = 0).
+        Test that _check_edge_flip_parity does not raise when all 12 edges are in oriented position.
 
         :param validator: Fixture of a Validator instance
+        :param cube_size: The size of the cube to validate
         :return: None
         """
 
-        cube = Cube(3)
-        # All edges have the primary color in position 0 (orientation = 0, total = 0)
+        cube = Cube(cube_size)
         edges = [
             (Color.WHITE, Color.GREEN),
             (Color.WHITE, Color.BLUE),
@@ -829,19 +647,52 @@ class TestValidatorCheckEdgeFlipParity:
             (Color.BLUE, Color.ORANGE),
             (Color.BLUE, Color.RED),
         ]
-        with patch.object(Validator, "_get_edges", return_value=edges):
+        with patch("rubik_cube_solver.validator.validator.get_edges", return_value=edges):
             validator._check_edge_flip_parity(cube)
 
-    def test_exception(self, validator: Validator) -> None:
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size", [3, 5]
+    )
+    # fmt: on
+    def test_success_six_flipped(self, validator: Validator, cube_size: int) -> None:
         """
-        Test that _check_edge_flip_parity raises ValueError when one edge is flipped (total = 1, which is odd).
+        Test that _check_edge_flip_parity does not raise when 6 edges are flipped.
+        """
+
+        cube = Cube(cube_size)
+        edges = [
+            (Color.WHITE, Color.GREEN),
+            (Color.BLUE, Color.WHITE),  # flipped UB edge
+            (Color.WHITE, Color.ORANGE),
+            (Color.RED, Color.WHITE),  # flipped UR edge
+            (Color.YELLOW, Color.GREEN),
+            (Color.BLUE, Color.YELLOW),  # flipped DB edge
+            (Color.YELLOW, Color.ORANGE),
+            (Color.RED, Color.YELLOW),  # flipped DR edge
+            (Color.GREEN, Color.ORANGE),
+            (Color.RED, Color.GREEN),  # flipped FR edge
+            (Color.BLUE, Color.ORANGE),
+            (Color.RED, Color.BLUE),  # flipped BR edge
+        ]
+        with patch("rubik_cube_solver.validator.validator.get_edges", return_value=edges):
+            validator._check_edge_flip_parity(cube)
+
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size", [3, 5]
+    )
+    # fmt: on
+    def test_exception_one_flipped(self, validator: Validator, cube_size: int) -> None:
+        """
+        Test that _check_edge_flip_parity raises ValueError when 1 edge is flipped.
 
         :param validator: Fixture of a Validator instance
+        :param cube_size: The size of the cube to validate
         :return: None
         """
 
-        cube = Cube(3)
-        # UF edge is flipped: GREEN is in position 0 instead of WHITE (orientation = 1, total = 1)
+        cube = Cube(cube_size)
         edges = [
             (Color.GREEN, Color.WHITE),  # flipped UF edge
             (Color.WHITE, Color.BLUE),
@@ -856,30 +707,69 @@ class TestValidatorCheckEdgeFlipParity:
             (Color.BLUE, Color.ORANGE),
             (Color.BLUE, Color.RED),
         ]
-        with patch.object(Validator, "_get_edges", return_value=edges):
+        with patch("rubik_cube_solver.validator.validator.get_edges", return_value=edges):
+            with pytest.raises(ValueError, match="Invalid edge flip parity"):
+                validator._check_edge_flip_parity(cube)
+
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size", [3, 5]
+    )
+    # fmt: on
+    def test_exception_seven_flipped(self, validator: Validator, cube_size: int) -> None:
+        """
+        Test that _check_edge_flip_parity raises ValueError when 7 edges are flipped.
+
+        :param validator: Fixture of a Validator instance
+        :param cube_size: The size of the cube to validate
+        :return: None
+        """
+
+        cube = Cube(cube_size)
+        edges = [
+            (Color.GREEN, Color.WHITE),  # flipped UF edge
+            (Color.BLUE, Color.WHITE),  # flipped UB edge
+            (Color.WHITE, Color.ORANGE),
+            (Color.RED, Color.WHITE),  # flipped UR edge
+            (Color.YELLOW, Color.GREEN),
+            (Color.BLUE, Color.YELLOW),  # flipped DB edge
+            (Color.YELLOW, Color.ORANGE),
+            (Color.RED, Color.YELLOW),  # flipped DR edge
+            (Color.GREEN, Color.ORANGE),
+            (Color.RED, Color.GREEN),  # flipped FR edge
+            (Color.BLUE, Color.ORANGE),
+            (Color.RED, Color.BLUE),  # flipped BR edge
+        ]
+        with patch("rubik_cube_solver.validator.validator.get_edges", return_value=edges):
             with pytest.raises(ValueError, match="Invalid edge flip parity"):
                 validator._check_edge_flip_parity(cube)
 
 
 class TestValidatorCheckPermutationParity:
-    def test_success(self, validator: Validator) -> None:
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size", [3, 5]
+    )
+    # fmt: on
+    def test_success(self, validator: Validator, cube_size: int) -> None:
         """
         Test that _check_permutation_parity does not raise when corners and edges are both in solved order (both even).
 
         :param validator: Fixture of a Validator instance
+        :param cube_size: The size of the cube to validate
         :return: None
         """
 
-        cube = Cube(3)
+        cube = Cube(cube_size)
         corners = [
-            (Color.WHITE, Color.GREEN, Color.ORANGE),  # UFL
-            (Color.WHITE, Color.RED, Color.GREEN),  # UFR
-            (Color.WHITE, Color.ORANGE, Color.BLUE),  # UBL
-            (Color.WHITE, Color.BLUE, Color.RED),  # UBR
-            (Color.YELLOW, Color.ORANGE, Color.GREEN),  # DFL
-            (Color.YELLOW, Color.GREEN, Color.RED),  # DFR
-            (Color.YELLOW, Color.BLUE, Color.ORANGE),  # DBL
-            (Color.YELLOW, Color.RED, Color.BLUE),  # DBR
+            (Color.WHITE, Color.GREEN, Color.ORANGE),
+            (Color.WHITE, Color.RED, Color.GREEN),
+            (Color.WHITE, Color.ORANGE, Color.BLUE),
+            (Color.WHITE, Color.BLUE, Color.RED),
+            (Color.YELLOW, Color.ORANGE, Color.GREEN),
+            (Color.YELLOW, Color.GREEN, Color.RED),
+            (Color.YELLOW, Color.BLUE, Color.ORANGE),
+            (Color.YELLOW, Color.RED, Color.BLUE),
         ]
         edges = [
             (Color.WHITE, Color.GREEN),
@@ -896,31 +786,37 @@ class TestValidatorCheckPermutationParity:
             (Color.BLUE, Color.RED),
         ]
         with (
-            patch.object(Validator, "_get_corners", return_value=corners),
-            patch.object(Validator, "_get_edges", return_value=edges),
+            patch("rubik_cube_solver.validator.validator.get_corners", return_value=corners),
+            patch("rubik_cube_solver.validator.validator.get_edges", return_value=edges),
         ):
             validator._check_permutation_parity(cube)
 
-    def test_exception(self, validator: Validator) -> None:
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size", [3, 5]
+    )
+    # fmt: on
+    def test_exception_swap_two_corners(self, validator: Validator, cube_size: int) -> None:
         """
         Test that _check_permutation_parity raises ValueError when two corners are swapped (odd corner parity)
         while edges remain in solved order (even parity).
 
         :param validator: Fixture of a Validator instance
+        :param cube_size: The size of the cube to validate
         :return: None
         """
 
-        cube = Cube(3)
+        cube = Cube(cube_size)
         # Swap UFL and UFR corners — this creates one inversion (odd corner parity)
         corners = [
             (Color.WHITE, Color.RED, Color.GREEN),  # UFR in UFL slot
             (Color.WHITE, Color.GREEN, Color.ORANGE),  # UFL in UFR slot
-            (Color.WHITE, Color.ORANGE, Color.BLUE),  # UBL
-            (Color.WHITE, Color.BLUE, Color.RED),  # UBR
-            (Color.YELLOW, Color.ORANGE, Color.GREEN),  # DFL
-            (Color.YELLOW, Color.GREEN, Color.RED),  # DFR
-            (Color.YELLOW, Color.BLUE, Color.ORANGE),  # DBL
-            (Color.YELLOW, Color.RED, Color.BLUE),  # DBR
+            (Color.WHITE, Color.ORANGE, Color.BLUE),
+            (Color.WHITE, Color.BLUE, Color.RED),
+            (Color.YELLOW, Color.ORANGE, Color.GREEN),
+            (Color.YELLOW, Color.GREEN, Color.RED),
+            (Color.YELLOW, Color.BLUE, Color.ORANGE),
+            (Color.YELLOW, Color.RED, Color.BLUE),
         ]
         edges = [
             (Color.WHITE, Color.GREEN),
@@ -937,8 +833,56 @@ class TestValidatorCheckPermutationParity:
             (Color.BLUE, Color.RED),
         ]
         with (
-            patch.object(Validator, "_get_corners", return_value=corners),
-            patch.object(Validator, "_get_edges", return_value=edges),
+            patch("rubik_cube_solver.validator.validator.get_corners", return_value=corners),
+            patch("rubik_cube_solver.validator.validator.get_edges", return_value=edges),
+        ):
+            with pytest.raises(ValueError, match="Invalid permutation parity"):
+                validator._check_permutation_parity(cube)
+
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size", [3, 5]
+    )
+    # fmt: on
+    def test_exception_swap_two_edges(self, validator: Validator, cube_size: int) -> None:
+        """
+        Test that _check_permutation_parity raises ValueError when two edges are swapped (odd edge parity)
+        while corners remain in solved order (even parity).
+
+        :param validator: Fixture of a Validator instance
+        :param cube_size: The size of the cube to validate
+        :return: None
+        """
+
+        cube = Cube(cube_size)
+        corners = [
+            (Color.WHITE, Color.GREEN, Color.ORANGE),
+            (Color.WHITE, Color.RED, Color.GREEN),
+            (Color.WHITE, Color.ORANGE, Color.BLUE),
+            (Color.WHITE, Color.BLUE, Color.RED),
+            (Color.YELLOW, Color.ORANGE, Color.GREEN),
+            (Color.YELLOW, Color.GREEN, Color.RED),
+            (Color.YELLOW, Color.BLUE, Color.ORANGE),
+            (Color.YELLOW, Color.RED, Color.BLUE),
+        ]
+        # Swap UF and UB corners — this creates one inversion (odd edge parity)
+        edges = [
+            (Color.WHITE, Color.BLUE),  # UB in UF slot
+            (Color.WHITE, Color.GREEN),  # UF in UB slot
+            (Color.WHITE, Color.ORANGE),
+            (Color.WHITE, Color.RED),
+            (Color.YELLOW, Color.GREEN),
+            (Color.YELLOW, Color.BLUE),
+            (Color.YELLOW, Color.ORANGE),
+            (Color.YELLOW, Color.RED),
+            (Color.GREEN, Color.ORANGE),
+            (Color.GREEN, Color.RED),
+            (Color.BLUE, Color.ORANGE),
+            (Color.BLUE, Color.RED),
+        ]
+        with (
+            patch("rubik_cube_solver.validator.validator.get_corners", return_value=corners),
+            patch("rubik_cube_solver.validator.validator.get_edges", return_value=edges),
         ):
             with pytest.raises(ValueError, match="Invalid permutation parity"):
                 validator._check_permutation_parity(cube)

--- a/solver/test/validator/validator_utils_test.py
+++ b/solver/test/validator/validator_utils_test.py
@@ -1,0 +1,52 @@
+# Python imports
+import pytest
+
+# Project imports
+from rubik_cube_solver.cube import Cube
+from rubik_cube_solver.validator.validator import Validator
+from rubik_cube_solver.validator.validator_constants import VALID_CORNER_COLOR_SETS, VALID_EDGE_COLOR_SETS
+from rubik_cube_solver.validator.validator_utils import get_corners, get_edges
+
+
+class TestValidatorGetCorners:
+    def test_success(self, validator: Validator) -> None:
+        """
+        Test that _get_corners returns the expected corners.
+
+        :param validator: Fixture of a Validator instance
+        :return: None
+        """
+
+        cube = Cube(3)
+        corners = get_corners(cube)
+        expected_corners = VALID_CORNER_COLOR_SETS
+
+        assert len(corners) == len(expected_corners)
+        for corner in corners:
+            assert isinstance(corner, tuple)
+            assert frozenset(corner) in expected_corners
+
+
+class TestValidatorGetEdges:
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size", [3, 5, 7]
+    )
+    # fmt: on
+    def test_success(self, validator: Validator, cube_size: int) -> None:
+        """
+        Test that _get_edges returns 12 edge tuples with correct sticker colors for a solved odd sized cube.
+
+        :param validator: Fixture of a Validator instance
+        :param cube_size: Fixture of size of the cube
+        :return: None
+        """
+
+        cube = Cube(cube_size)
+        edges = get_edges(cube)
+        expected_edges = VALID_EDGE_COLOR_SETS
+
+        assert len(edges) == len(expected_edges)
+        for edge in edges:
+            assert isinstance(edge, tuple)
+            assert frozenset(edge) in expected_edges


### PR DESCRIPTION
## Summary
- Implement 4 new odd sized cubes specific validation checks: center uniqueness, edge validity, edge flip parity, and permutation parity
- These checks are gated on `cube.size % 2 == 1` and run after the existing corner checks
- Unit tests cover all 4 new check methods and updated the `validate` orchestration tests to assert odd sized cubes specific methods are called or skipped as appropriate

## Related issues
Closes #191
Closes #196