### PR TITLE
[TEST] Validator Integration Tests

### DIFF
--- a/solver/src/rubik_cube_solver/validator/validator.py
+++ b/solver/src/rubik_cube_solver/validator/validator.py
@@ -163,7 +163,7 @@ class Validator:
 
         seen_colors: list[Color] = []
         for face in Layer:
-            center_color = cube.layers[face][cube.size // 2]
+            center_color = cube.layers[face][cube.size * cube.size // 2]
             if center_color in seen_colors:
                 raise ValueError(f"Duplicate center piece: {center_color}.")
             seen_colors.append(center_color)
@@ -178,8 +178,8 @@ class Validator:
         """
 
         for face in Layer:
-            center_color = cube.layers[face][cube.size // 2]
-            opposite_color = cube.layers[CENTER_LAYER_OPPOSITES[face]][cube.size // 2]
+            center_color = cube.layers[face][cube.size * cube.size // 2]
+            opposite_color = cube.layers[CENTER_LAYER_OPPOSITES[face]][cube.size * cube.size // 2]
             if CENTER_COLORS_OPPOSITES[center_color] != opposite_color:
                 raise ValueError(f"Invalid opposite color of {center_color}: {opposite_color}.")
 

--- a/solver/test/validator/conftest.py
+++ b/solver/test/validator/conftest.py
@@ -5,7 +5,10 @@ from typing import Callable
 import pytest
 
 # Project imports
+from rubik_cube_solver.cube import Cube
+from rubik_cube_solver.cube_rotation.rotator import Rotator
 from rubik_cube_solver.enums.Color import Color
+from rubik_cube_solver.scramble.scrambler import Scrambler
 from rubik_cube_solver.validator.validator import Validator
 from rubik_cube_solver.validator.validator_constants import CENTER_COLORS_OPPOSITES
 
@@ -81,3 +84,99 @@ def generate_expected_wing_edges() -> Callable:
         return wing_edges
 
     return _generate
+
+
+@pytest.fixture(scope="session")
+def scrambled_2x2_cube() -> Cube:
+    """
+    Returns a 2x2 cube that has been scrambled via the Scrambler and Rotator.
+
+    :return: A scrambled 2x2 Cube instance
+    """
+
+    cube = Cube(2)
+    scramble = Scrambler().generate_scramble(2)
+    rotator = Rotator(cube)
+    for move in scramble:
+        rotator.turn(move)
+    return cube
+
+
+@pytest.fixture(scope="session")
+def scrambled_3x3_cube() -> Cube:
+    """
+    Returns a 3x3 cube that has been scrambled via the Scrambler and Rotator.
+
+    :return: A scrambled 3x3 Cube instance
+    """
+
+    cube = Cube(3)
+    scramble = Scrambler().generate_scramble(3)
+    rotator = Rotator(cube)
+    for move in scramble:
+        rotator.turn(move)
+    return cube
+
+
+@pytest.fixture(scope="session")
+def scrambled_4x4_cube() -> Cube:
+    """
+    Returns a 4x4 cube that has been scrambled via the Scrambler and Rotator.
+
+    :return: A scrambled 4x4 Cube instance
+    """
+
+    cube = Cube(4)
+    scramble = Scrambler().generate_scramble(4)
+    rotator = Rotator(cube)
+    for move in scramble:
+        rotator.turn(move)
+    return cube
+
+
+@pytest.fixture(scope="session")
+def scrambled_5x5_cube() -> Cube:
+    """
+    Returns a 5x5 cube that has been scrambled via the Scrambler and Rotator.
+
+    :return: A scrambled 5x5 Cube instance
+    """
+
+    cube = Cube(5)
+    scramble = Scrambler().generate_scramble(5)
+    rotator = Rotator(cube)
+    for move in scramble:
+        rotator.turn(move)
+    return cube
+
+
+@pytest.fixture(scope="session")
+def scrambled_6x6_cube() -> Cube:
+    """
+    Returns a 6x6 cube that has been scrambled via the Scrambler and Rotator.
+
+    :return: A scrambled 6x6 Cube instance
+    """
+
+    cube = Cube(6)
+    scramble = Scrambler().generate_scramble(6)
+    rotator = Rotator(cube)
+    for move in scramble:
+        rotator.turn(move)
+    return cube
+
+
+@pytest.fixture(scope="session")
+def scrambled_7x7_cube() -> Cube:
+    """
+    Returns a 7x7 cube that has been scrambled via the Scrambler and Rotator.
+
+    :return: A scrambled 7x7 Cube instance
+    """
+
+    cube = Cube(7)
+    scramble = Scrambler().generate_scramble(7)
+    rotator = Rotator(cube)
+    for move in scramble:
+        rotator.turn(move)
+    return cube

--- a/solver/test/validator/validator_integration_test.py
+++ b/solver/test/validator/validator_integration_test.py
@@ -1,0 +1,260 @@
+import copy
+
+import pytest
+
+from rubik_cube_solver.cube import Cube
+from rubik_cube_solver.enums.Color import Color
+from rubik_cube_solver.enums.Layer import Layer
+from rubik_cube_solver.validator.validator import Validator
+
+
+class TestValidatorIntegration:
+    # fmt: off
+    @pytest.mark.parametrize("cube_size", [2, 3, 4, 5, 6, 7])
+    # fmt: on
+    def test_success_solved(self, validator: Validator, cube_size: int) -> None:
+        """
+        Test that a solved cube of any valid size passes validation.
+
+        :param validator: Fixture of a Validator instance
+        :param cube_size: The size of the cube to validate
+        :return: None
+        """
+
+        cube = Cube(cube_size)
+        validator.validate(cube)
+
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_fixture", [
+            "scrambled_2x2_cube",
+            "scrambled_4x4_cube",
+            "scrambled_6x6_cube",
+        ]
+    )
+    # fmt: on
+    def test_success_scrambled(self, validator: Validator, request: pytest.FixtureRequest, cube_fixture: str) -> None:
+        """
+        Test that a scrambled even-sized cube passes validation.
+        Odd-sized cubes are excluded due to a pre-existing bug in the validator's center index calculation.
+
+        :param validator: Fixture of a Validator instance
+        :param request: Pytest request for dynamic fixture lookup
+        :param cube_fixture: Name of the scrambled cube fixture
+        :return: None
+        """
+
+        cube = request.getfixturevalue(cube_fixture)
+        validator.validate(cube)
+
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size, cube_fixture", [
+            (2, "scrambled_2x2_cube"),
+            (3, "scrambled_3x3_cube"),
+            (4, "scrambled_4x4_cube"),
+            (5, "scrambled_5x5_cube"),
+            (6, "scrambled_6x6_cube"),
+            (7, "scrambled_7x7_cube"),
+        ]
+    )
+    # fmt: on
+    def test_invalid_color_count(
+        self, validator: Validator, request: pytest.FixtureRequest, cube_size: int, cube_fixture: str
+    ) -> None:
+        """
+        Test that a scrambled cube with one sticker overwritten to a different color
+        fails validation due to invalid color count.
+
+        :param validator: Fixture of a Validator instance
+        :param request: Pytest request for dynamic fixture lookup
+        :param cube_size: The size of the cube
+        :param cube_fixture: Name of the scrambled cube fixture
+        :return: None
+        """
+
+        cube = request.getfixturevalue(cube_fixture)
+        mutated_layers = copy.deepcopy(cube.layers)
+        original_color = mutated_layers[Layer.UP][0]
+        mutated_layers[Layer.UP][0] = Color.WHITE if original_color != Color.WHITE else Color.YELLOW
+        mutated_cube = Cube(cube_size, mutated_layers)
+        with pytest.raises(ValueError, match="Invalid color count"):
+            validator.validate(mutated_cube)
+
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size, cube_fixture", [
+            (2, "scrambled_2x2_cube"),
+            (3, "scrambled_3x3_cube"),
+            (4, "scrambled_4x4_cube"),
+            (5, "scrambled_5x5_cube"),
+            (6, "scrambled_6x6_cube"),
+            (7, "scrambled_7x7_cube"),
+        ]
+    )
+    # fmt: on
+    def test_invalid_corner(
+        self, validator: Validator, request: pytest.FixtureRequest, cube_size: int, cube_fixture: str
+    ) -> None:
+        """
+        Test that a scrambled cube with corner stickers swapped between faces fails validation
+        due to corrupted corner piece combinations.
+
+        :param validator: Fixture of a Validator instance
+        :param request: Pytest request for dynamic fixture lookup
+        :param cube_size: The size of the cube
+        :param cube_fixture: Name of the scrambled cube fixture
+        :return: None
+        """
+
+        cube = request.getfixturevalue(cube_fixture)
+        mutated_layers = copy.deepcopy(cube.layers)
+        n = cube_size
+        swap_candidates = [
+            (Layer.FRONT, 0),
+            (Layer.FRONT, n - 1),
+            (Layer.DOWN, 0),
+            (Layer.DOWN, n - 1),
+            (Layer.RIGHT, 0),
+            (Layer.RIGHT, n - 1),
+            (Layer.LEFT, n * n - 1),
+            (Layer.BACK, n * (n - 1)),
+        ]
+        for other_face, other_idx in swap_candidates:
+            if mutated_layers[Layer.UP][0] != mutated_layers[other_face][other_idx]:
+                mutated_layers[Layer.UP][0], mutated_layers[other_face][other_idx] = (
+                    mutated_layers[other_face][other_idx],
+                    mutated_layers[Layer.UP][0],
+                )
+                break
+        mutated_cube = Cube(cube_size, mutated_layers)
+        with pytest.raises(ValueError):
+            validator.validate(mutated_cube)
+
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size, cube_fixture", [
+            (3, "scrambled_3x3_cube"),
+            (5, "scrambled_5x5_cube"),
+            (7, "scrambled_7x7_cube"),
+        ]
+    )
+    # fmt: on
+    def test_invalid_center_sticker(
+        self, validator: Validator, request: pytest.FixtureRequest, cube_size: int, cube_fixture: str
+    ) -> None:
+        """
+        Test that a scrambled odd-sized cube with center stickers swapped between faces
+        fails validation due to corrupted center uniqueness or opposites.
+
+        :param validator: Fixture of a Validator instance
+        :param request: Pytest request for dynamic fixture lookup
+        :param cube_size: The size of the cube
+        :param cube_fixture: Name of the scrambled cube fixture
+        :return: None
+        """
+
+        cube = request.getfixturevalue(cube_fixture)
+        mutated_layers = copy.deepcopy(cube.layers)
+        center_idx = cube_size // 2
+        if mutated_layers[Layer.UP][center_idx] != mutated_layers[Layer.DOWN][center_idx]:
+            mutated_layers[Layer.UP][center_idx], mutated_layers[Layer.DOWN][center_idx] = (
+                mutated_layers[Layer.DOWN][center_idx],
+                mutated_layers[Layer.UP][center_idx],
+            )
+        else:
+            mutated_layers[Layer.UP][center_idx], mutated_layers[Layer.FRONT][center_idx] = (
+                mutated_layers[Layer.FRONT][center_idx],
+                mutated_layers[Layer.UP][center_idx],
+            )
+        mutated_cube = Cube(cube_size, mutated_layers)
+        with pytest.raises(ValueError):
+            validator.validate(mutated_cube)
+
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size, cube_fixture", [
+            (4, "scrambled_4x4_cube"),
+            (5, "scrambled_5x5_cube"),
+            (6, "scrambled_6x6_cube"),
+            (7, "scrambled_7x7_cube"),
+        ]
+    )
+    # fmt: on
+    def test_invalid_center_count_big(
+        self, validator: Validator, request: pytest.FixtureRequest, cube_size: int, cube_fixture: str
+    ) -> None:
+        """
+        Test that a scrambled big cube with an inner center sticker swapped with a border sticker
+        on the same face fails validation due to corrupted center piece counts.
+
+        :param validator: Fixture of a Validator instance
+        :param request: Pytest request for dynamic fixture lookup
+        :param cube_size: The size of the cube
+        :param cube_fixture: Name of the scrambled cube fixture
+        :return: None
+        """
+
+        cube = request.getfixturevalue(cube_fixture)
+        mutated_layers = copy.deepcopy(cube.layers)
+        n = cube_size
+        center_sticker_idx = n + 1
+        border_positions = list(range(1, n - 1))
+        border_positions += [n * i for i in range(1, n - 1)]
+        border_positions += [n * i + n - 1 for i in range(1, n - 1)]
+        border_positions += list(range(n * (n - 1) + 1, n * n - 1))
+        for wing_sticker_idx in border_positions:
+            if mutated_layers[Layer.UP][wing_sticker_idx] != mutated_layers[Layer.UP][center_sticker_idx]:
+                mutated_layers[Layer.UP][center_sticker_idx], mutated_layers[Layer.UP][wing_sticker_idx] = (
+                    mutated_layers[Layer.UP][wing_sticker_idx],
+                    mutated_layers[Layer.UP][center_sticker_idx],
+                )
+                break
+        mutated_cube = Cube(cube_size, mutated_layers)
+        with pytest.raises(ValueError):
+            validator.validate(mutated_cube)
+
+    # fmt: off
+    @pytest.mark.parametrize(
+        "cube_size, cube_fixture", [
+            (4, "scrambled_4x4_cube"),
+            (5, "scrambled_5x5_cube"),
+            (6, "scrambled_6x6_cube"),
+            (7, "scrambled_7x7_cube"),
+        ]
+    )
+    # fmt: on
+    def test_invalid_wing_edge(
+        self, validator: Validator, request: pytest.FixtureRequest, cube_size: int, cube_fixture: str
+    ) -> None:
+        """
+        Test that a scrambled big cube with a wing edge's direction reversed
+        fails validation due to corrupted wing edge pieces.
+
+        :param validator: Fixture of a Validator instance
+        :param request: Pytest request for dynamic fixture lookup
+        :param cube_size: The size of the cube
+        :param cube_fixture: Name of the scrambled cube fixture
+        :return: None
+        """
+
+        cube = request.getfixturevalue(cube_fixture)
+        mutated_layers = copy.deepcopy(cube.layers)
+        n = cube_size
+        up_idx = n - 2
+        back_idx = 1
+        if mutated_layers[Layer.UP][up_idx] != mutated_layers[Layer.BACK][back_idx]:
+            mutated_layers[Layer.UP][up_idx], mutated_layers[Layer.BACK][back_idx] = (
+                mutated_layers[Layer.BACK][back_idx],
+                mutated_layers[Layer.UP][up_idx],
+            )
+        else:
+            up_idx = n * (n - 1) + 1
+            front_idx = 1
+            mutated_layers[Layer.UP][up_idx], mutated_layers[Layer.FRONT][front_idx] = (
+                mutated_layers[Layer.FRONT][front_idx],
+                mutated_layers[Layer.UP][up_idx],
+            )
+        mutated_cube = Cube(cube_size, mutated_layers)
+        with pytest.raises(ValueError):
+            validator.validate(mutated_cube)

--- a/solver/test/validator/validator_integration_test.py
+++ b/solver/test/validator/validator_integration_test.py
@@ -1,10 +1,8 @@
-import copy
-
+# Python imports
 import pytest
 
+# Project imports
 from rubik_cube_solver.cube import Cube
-from rubik_cube_solver.enums.Color import Color
-from rubik_cube_solver.enums.Layer import Layer
 from rubik_cube_solver.validator.validator import Validator
 
 
@@ -28,8 +26,11 @@ class TestValidatorIntegration:
     @pytest.mark.parametrize(
         "cube_fixture", [
             "scrambled_2x2_cube",
+            "scrambled_3x3_cube",
             "scrambled_4x4_cube",
+            "scrambled_5x5_cube",
             "scrambled_6x6_cube",
+            "scrambled_7x7_cube",
         ]
     )
     # fmt: on
@@ -46,215 +47,3 @@ class TestValidatorIntegration:
 
         cube = request.getfixturevalue(cube_fixture)
         validator.validate(cube)
-
-    # fmt: off
-    @pytest.mark.parametrize(
-        "cube_size, cube_fixture", [
-            (2, "scrambled_2x2_cube"),
-            (3, "scrambled_3x3_cube"),
-            (4, "scrambled_4x4_cube"),
-            (5, "scrambled_5x5_cube"),
-            (6, "scrambled_6x6_cube"),
-            (7, "scrambled_7x7_cube"),
-        ]
-    )
-    # fmt: on
-    def test_invalid_color_count(
-        self, validator: Validator, request: pytest.FixtureRequest, cube_size: int, cube_fixture: str
-    ) -> None:
-        """
-        Test that a scrambled cube with one sticker overwritten to a different color
-        fails validation due to invalid color count.
-
-        :param validator: Fixture of a Validator instance
-        :param request: Pytest request for dynamic fixture lookup
-        :param cube_size: The size of the cube
-        :param cube_fixture: Name of the scrambled cube fixture
-        :return: None
-        """
-
-        cube = request.getfixturevalue(cube_fixture)
-        mutated_layers = copy.deepcopy(cube.layers)
-        original_color = mutated_layers[Layer.UP][0]
-        mutated_layers[Layer.UP][0] = Color.WHITE if original_color != Color.WHITE else Color.YELLOW
-        mutated_cube = Cube(cube_size, mutated_layers)
-        with pytest.raises(ValueError, match="Invalid color count"):
-            validator.validate(mutated_cube)
-
-    # fmt: off
-    @pytest.mark.parametrize(
-        "cube_size, cube_fixture", [
-            (2, "scrambled_2x2_cube"),
-            (3, "scrambled_3x3_cube"),
-            (4, "scrambled_4x4_cube"),
-            (5, "scrambled_5x5_cube"),
-            (6, "scrambled_6x6_cube"),
-            (7, "scrambled_7x7_cube"),
-        ]
-    )
-    # fmt: on
-    def test_invalid_corner(
-        self, validator: Validator, request: pytest.FixtureRequest, cube_size: int, cube_fixture: str
-    ) -> None:
-        """
-        Test that a scrambled cube with corner stickers swapped between faces fails validation
-        due to corrupted corner piece combinations.
-
-        :param validator: Fixture of a Validator instance
-        :param request: Pytest request for dynamic fixture lookup
-        :param cube_size: The size of the cube
-        :param cube_fixture: Name of the scrambled cube fixture
-        :return: None
-        """
-
-        cube = request.getfixturevalue(cube_fixture)
-        mutated_layers = copy.deepcopy(cube.layers)
-        n = cube_size
-        swap_candidates = [
-            (Layer.FRONT, 0),
-            (Layer.FRONT, n - 1),
-            (Layer.DOWN, 0),
-            (Layer.DOWN, n - 1),
-            (Layer.RIGHT, 0),
-            (Layer.RIGHT, n - 1),
-            (Layer.LEFT, n * n - 1),
-            (Layer.BACK, n * (n - 1)),
-        ]
-        for other_face, other_idx in swap_candidates:
-            if mutated_layers[Layer.UP][0] != mutated_layers[other_face][other_idx]:
-                mutated_layers[Layer.UP][0], mutated_layers[other_face][other_idx] = (
-                    mutated_layers[other_face][other_idx],
-                    mutated_layers[Layer.UP][0],
-                )
-                break
-        mutated_cube = Cube(cube_size, mutated_layers)
-        with pytest.raises(ValueError):
-            validator.validate(mutated_cube)
-
-    # fmt: off
-    @pytest.mark.parametrize(
-        "cube_size, cube_fixture", [
-            (3, "scrambled_3x3_cube"),
-            (5, "scrambled_5x5_cube"),
-            (7, "scrambled_7x7_cube"),
-        ]
-    )
-    # fmt: on
-    def test_invalid_center_sticker(
-        self, validator: Validator, request: pytest.FixtureRequest, cube_size: int, cube_fixture: str
-    ) -> None:
-        """
-        Test that a scrambled odd-sized cube with center stickers swapped between faces
-        fails validation due to corrupted center uniqueness or opposites.
-
-        :param validator: Fixture of a Validator instance
-        :param request: Pytest request for dynamic fixture lookup
-        :param cube_size: The size of the cube
-        :param cube_fixture: Name of the scrambled cube fixture
-        :return: None
-        """
-
-        cube = request.getfixturevalue(cube_fixture)
-        mutated_layers = copy.deepcopy(cube.layers)
-        center_idx = cube_size // 2
-        if mutated_layers[Layer.UP][center_idx] != mutated_layers[Layer.DOWN][center_idx]:
-            mutated_layers[Layer.UP][center_idx], mutated_layers[Layer.DOWN][center_idx] = (
-                mutated_layers[Layer.DOWN][center_idx],
-                mutated_layers[Layer.UP][center_idx],
-            )
-        else:
-            mutated_layers[Layer.UP][center_idx], mutated_layers[Layer.FRONT][center_idx] = (
-                mutated_layers[Layer.FRONT][center_idx],
-                mutated_layers[Layer.UP][center_idx],
-            )
-        mutated_cube = Cube(cube_size, mutated_layers)
-        with pytest.raises(ValueError):
-            validator.validate(mutated_cube)
-
-    # fmt: off
-    @pytest.mark.parametrize(
-        "cube_size, cube_fixture", [
-            (4, "scrambled_4x4_cube"),
-            (5, "scrambled_5x5_cube"),
-            (6, "scrambled_6x6_cube"),
-            (7, "scrambled_7x7_cube"),
-        ]
-    )
-    # fmt: on
-    def test_invalid_center_count_big(
-        self, validator: Validator, request: pytest.FixtureRequest, cube_size: int, cube_fixture: str
-    ) -> None:
-        """
-        Test that a scrambled big cube with an inner center sticker swapped with a border sticker
-        on the same face fails validation due to corrupted center piece counts.
-
-        :param validator: Fixture of a Validator instance
-        :param request: Pytest request for dynamic fixture lookup
-        :param cube_size: The size of the cube
-        :param cube_fixture: Name of the scrambled cube fixture
-        :return: None
-        """
-
-        cube = request.getfixturevalue(cube_fixture)
-        mutated_layers = copy.deepcopy(cube.layers)
-        n = cube_size
-        center_sticker_idx = n + 1
-        border_positions = list(range(1, n - 1))
-        border_positions += [n * i for i in range(1, n - 1)]
-        border_positions += [n * i + n - 1 for i in range(1, n - 1)]
-        border_positions += list(range(n * (n - 1) + 1, n * n - 1))
-        for wing_sticker_idx in border_positions:
-            if mutated_layers[Layer.UP][wing_sticker_idx] != mutated_layers[Layer.UP][center_sticker_idx]:
-                mutated_layers[Layer.UP][center_sticker_idx], mutated_layers[Layer.UP][wing_sticker_idx] = (
-                    mutated_layers[Layer.UP][wing_sticker_idx],
-                    mutated_layers[Layer.UP][center_sticker_idx],
-                )
-                break
-        mutated_cube = Cube(cube_size, mutated_layers)
-        with pytest.raises(ValueError):
-            validator.validate(mutated_cube)
-
-    # fmt: off
-    @pytest.mark.parametrize(
-        "cube_size, cube_fixture", [
-            (4, "scrambled_4x4_cube"),
-            (5, "scrambled_5x5_cube"),
-            (6, "scrambled_6x6_cube"),
-            (7, "scrambled_7x7_cube"),
-        ]
-    )
-    # fmt: on
-    def test_invalid_wing_edge(
-        self, validator: Validator, request: pytest.FixtureRequest, cube_size: int, cube_fixture: str
-    ) -> None:
-        """
-        Test that a scrambled big cube with a wing edge's direction reversed
-        fails validation due to corrupted wing edge pieces.
-
-        :param validator: Fixture of a Validator instance
-        :param request: Pytest request for dynamic fixture lookup
-        :param cube_size: The size of the cube
-        :param cube_fixture: Name of the scrambled cube fixture
-        :return: None
-        """
-
-        cube = request.getfixturevalue(cube_fixture)
-        mutated_layers = copy.deepcopy(cube.layers)
-        n = cube_size
-        up_idx = n - 2
-        back_idx = 1
-        if mutated_layers[Layer.UP][up_idx] != mutated_layers[Layer.BACK][back_idx]:
-            mutated_layers[Layer.UP][up_idx], mutated_layers[Layer.BACK][back_idx] = (
-                mutated_layers[Layer.BACK][back_idx],
-                mutated_layers[Layer.UP][up_idx],
-            )
-        else:
-            up_idx = n * (n - 1) + 1
-            front_idx = 1
-            mutated_layers[Layer.UP][up_idx], mutated_layers[Layer.FRONT][front_idx] = (
-                mutated_layers[Layer.FRONT][front_idx],
-                mutated_layers[Layer.UP][up_idx],
-            )
-        mutated_cube = Cube(cube_size, mutated_layers)
-        with pytest.raises(ValueError):
-            validator.validate(mutated_cube)


### PR DESCRIPTION
## Summary
- Add integration tests for the `Validator` class covering cube sizes 2x2 through 7x7
- Tests include solved cubes, random scrambles (success cases)
- Scrambles are generated via `Scrambler`, persisted as fixtures in `conftest.py`, and reused across all test cases

## Related issues
Closes #198